### PR TITLE
Slim packages

### DIFF
--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -24,7 +24,8 @@ on:
         default: "benjaminkirk/gh-ci"
         options:
           - "benjaminkirk/gh-ci"
-          - "ncarcisl/hpcdev"
+          - "benjaminkirk/hpcdev"
+          - "ncarcisl/gh-ci"
 
       test:
         description: 'Test Image'

--- a/.github/workflows/devel-hpc-development-image.yaml
+++ b/.github/workflows/devel-hpc-development-image.yaml
@@ -305,6 +305,7 @@ jobs:
 
       - name: Test Image - FastEddy
         if: ${{ inputs.test && inputs.gpu != 'nogpu' }}
+        continue-on-error: true
         run: |
           docker run --rm --env-file test_env.cfg \
             ${{ env.CI_TAG }} \

--- a/.github/workflows/devel-hpc-development-image.yaml
+++ b/.github/workflows/devel-hpc-development-image.yaml
@@ -303,6 +303,13 @@ jobs:
             ${{ env.CI_TAG }} \
             /container/extras/build_dart.sh
 
+      - name: Test Image - FastEddy
+        if: ${{ inputs.test && inputs.gpu != 'nogpu' }}
+        run: |
+          docker run --rm --env-file test_env.cfg \
+            ${{ env.CI_TAG }} \
+            /container/extras/build_fasteddy.sh
+
       - name: Test Image - Kokkos
         if: ${{ inputs.test }}
         continue-on-error: ${{ inputs.gpu == 'nogpu' && false || true }}

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -17,6 +17,15 @@ on:
           - leap
           - tumbleweed
 
+      docker_repo:
+        description: "Docker Repository for Deployment"
+        type: choice
+        required: true
+        default: "ncarcisl/hpcdev"
+        options:
+          - "benjaminkirk/gh-ci"
+          - "ncarcisl/hpcdev"
+
       test:
         description: 'Test Image'
         type: boolean
@@ -143,6 +152,7 @@ jobs:
 
     uses: ./.github/workflows/build-hpc-development-image.yaml
     with:
+      docker_repo: ${{ inputs.docker_repo }}
       os: ${{ inputs.os }}
       arch: ${{ matrix.arch }}
       runner: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -24,6 +24,8 @@ on:
         default: "ncarcisl/hpcdev"
         options:
           - "benjaminkirk/gh-ci"
+          - "benjaminkirk/hpcdev"
+          - "ncarcisl/gh-ci"
           - "ncarcisl/hpcdev"
 
       test:

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -76,6 +76,7 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<'FILE3' cat > /container/bin/list-large-directories && \
     <<'FILE4' cat > /container/bin/add_conf && \
     <<'FILE5' cat > /container/bin/strip-binaries \
+    <<'FILE6' cat > /container/bin/remove-redundant-static-libs \
     && chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
     && ln -s /container/config_env.sh /etc/profile.d/z00-build-env.sh
@@ -95,19 +96,19 @@ unset TOGGLE_WITH_ROCM
 FILE1
 #!/bin/bash
 echo "[${0}]: cleaning temporary files from container image to reduce layer size"
-[ -x "$(command -v yum)" ] && yum clean all
-[ -x "$(command -v apt)" ] && apt clean
-[ -x "$(command -v zypper)" ] && zypper clean -a
-[ -x "$(command -v conda)" ] && conda clean --all --yes
+[[ -x "$(command -v yum)" ]] && yum clean all
+[[ -x "$(command -v apt)" ]] && apt clean
+[[ -x "$(command -v zypper)" ]] && zypper clean -a
+[[ -x "$(command -v conda)" ]] && conda clean --all --yes
 for dir in /tmp/* /var/tmp/* /home/jupyter/{.ccache,.cache/pip,conda-bld,.conda} /root/* /root/.[^.]* /var/lib/apt/lists /var/log/* ; do
-    [ -e ${dir} ] && rm -rf ${dir} 2>/dev/null || true
+    [[ -e ${dir} ]] && rm -rf ${dir} 2>/dev/null || true
 done
 rm -rf /tmp/*
 FILE2
 #!/bin/bash
 
 dirs="/home /mnt /tmp /opt /usr /var /container"
-if [ ${#} -ge 1 ]; then
+if [[ ${#} -ge 1 ]]; then
     dirs=${@}
 fi
 
@@ -116,7 +117,7 @@ THRESHOLD_SIZE_MB=4
 echo "[${0}]: Finding large files & directories >${THRESHOLD_SIZE_MB}MiB in ${dirs} - output is MiB"
 for dir in ${dirs}; do
     dir=$(realpath ${dir})
-    if [ -d ${dir} ]; then
+    if [[ -d ${dir} ]]; then
         find 2>/dev/null ${dir} -type f -size +${THRESHOLD_SIZE_MB}M -print0 | xargs -0 --no-run-if-empty du --block-size=1MiB | sort -n
         du 2>/dev/null --block-size=1MiB --threshold=${THRESHOLD_SIZE_MB}MiB --separate-dirs ${dir} | sort -n
     fi
@@ -137,7 +138,7 @@ FILE4
 
 set -eu
 
-if [ ${#} -ne 1 ]; then
+if [[ ${#} -ne 1 ]]; then
     echo "Usage: ${0} <directory path>"
     exit 1
 fi
@@ -155,17 +156,46 @@ time find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs --no-run-if-empty strip -s
-
-echo "Re-indexing static libraries with ranlib..."
-time find -L ${dir} -type f -exec readlink -f '{}' \; | \
-    xargs file -i | \
-    grep 'charset=binary' | \
-    grep 'x-archive' | \
-    awk -F: '{print $1}' | xargs -n1 --no-run-if-empty ranlib
+    awk -F: '{print $1}' | xargs --no-run-if-empty strip --strip-debug --preserve-dates
 
 echo "After: $(du -hs ${dir})"
 FILE5
+#!/bin/bash
+
+set -eu
+
+if [[ ${#} -ne 1 ]]; then
+    echo "Usage: ${0} <directory path>"
+    exit 1
+fi
+
+dir=$(realpath ${1})
+
+[[ -d "${dir}" ]] \
+  && echo "[${BASH_SOURCE[0]}]: Removing redundant static libraries from ${dir}..." \
+  || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+
+while read -r static_lib; do
+
+    # Check CUDA-stylee libcufoo.so / libcufoo_static.a}
+    shared_lib=${static_lib//'_static.a'/'.so'}
+
+    if [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
+    fi
+
+    # Check typical libfoo.so / libfoo.a}
+    shared_lib=${static_lib//'.a'/'.so'}
+
+    if [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
+    fi
+done < <(find ${dir} -type f -name "lib*.a")
+FILE6
 
 
 # Initialize the base OS; whether it is a RHEL, SUSE, or Ubuntu variant to provide
@@ -271,8 +301,6 @@ ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
 RUN exec &> >(tee /container/logs/cuda.log) && \
-    <<'FILE1' cat > /container/bin/remove-cuda-static-libs \
-    && chmod +x /container/bin/* \
     && cd /tmp \
     && env \
     && echo "Cuda v${CUDA_VERSION} - runfile installer" \
@@ -289,7 +317,7 @@ RUN exec &> >(tee /container/logs/cuda.log) && \
     && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
-    && remove-cuda-static-libs \
+    && remove-redundant-static-libs ${CUDA_HOME} >> README.whered_stuff_go \
     && cat README.whered_stuff_go \
     && find ${CUDA_HOME} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && add_conf "\n# CUDA ${CUDA_VERSION}" \
@@ -306,22 +334,6 @@ RUN exec &> >(tee /container/logs/cuda.log) && \
     && echo "${CUDA_STUBDIR}" >> /etc/ld.so.conf.d/cuda*.conf \
     && ldconfig --verbose \
     && docker-clean
-#!/bin/bash
-echo "[${BASH_SOURCE[0]}]: Removing CUDA Toolkit static libraries when a suitable shared library exists..."
-
-while read -r static_lib; do
-
-    shared_lib=${static_lib//'_static.a'/'.so'}
-
-    if [[ -f ${shared_lib} ]]; then
-        shared_lib=$(realpath ${shared_lib})
-        ls -lh ${static_lib} ${shared_lib}
-        rm -vf ${static_lib} >> README.whered_stuff_go
-        #ln -sf ${shared_lib} ${static_lib}
-    fi
-
-done < <(find ${CUDA_HOME} -type f -name "lib*_static.a")
-FILE1
 
 # # A sourceable script to query the CUDA configuration at runtime.
 # # (intended to simplify setting compatibility variables for

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -300,7 +300,7 @@ ARG CUDA_VERSION="12.9"
 ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run"
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
-RUN exec &> >(tee /container/logs/cuda.log) && \
+RUN exec &> >(tee /container/logs/cuda.log) \
     && cd /tmp \
     && env \
     && echo "Cuda v${CUDA_VERSION} - runfile installer" \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<FILE1   cat > /container/config_env.sh && \
     <<'FILE2' cat > /container/bin/docker-clean && \
     <<'FILE3' cat > /container/bin/list-large-directories && \
-    <<'FILE4' cat > /container/bin/add_conf \
+    <<'FILE4' cat > /container/bin/add_conf && \
     <<'FILE5' cat > /container/bin/strip-binaries \
     && chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
@@ -804,7 +804,7 @@ RUN exec &> >(tee /container/logs/mpich.log) \
            --disable-dependency-tracking \
             || cat config.log) \
     && make --no-print-directory --jobs ${MAKE_J_PROCS} V=0 \
-    && make --no-print-directory --silent install \
+    && make --no-print-directory --silent install-strip \
     && add_conf "\n# MPICH ${MPICH_VERSION}" \
     && add_conf "export MPI_FAMILY=mpich" \
     && add_conf "export MPI_ROOT=${MPICH_INSTALL_PATH}"  \
@@ -857,7 +857,7 @@ RUN exec &> >(tee /container/logs/mpich.log) \
            --disable-dependency-tracking \
             || cat config.log) \
     && make --no-print-directory --jobs ${MAKE_J_PROCS} V=0 \
-    && make --no-print-directory --silent install \
+    && make --no-print-directory --silent install-strip \
     && add_conf "\n# MPICH ${MPICH_VERSION}" \
     && add_conf "export MPI_FAMILY=mpich" \
     && add_conf "export MPI_ROOT=${MPICH_INSTALL_PATH}" \
@@ -905,7 +905,7 @@ RUN exec &> >(tee /container/logs/openmpi.log) \
            --disable-dependency-tracking \
             || cat config.log) \
     && make --no-print-directory --jobs ${MAKE_J_PROCS} V=0 \
-    && make --no-print-directory --silent install \
+    && make --no-print-directory --silent install-strip \
     && cd ${OPENMPI_INSTALL_PATH} \
     && rm_paths="share/doc/" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -144,7 +144,7 @@ fi
 
 dir=$(realpath ${1})
 
-[ -d "${dir}" ] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+[ -d "${dir}" ] && echo "Stripping all libraries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
 echo "Before: $(du -hs ${dir})"
 
@@ -152,8 +152,15 @@ echo "Before: $(du -hs ${dir})"
 find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
-    grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip -s
+    grep 'x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs --no-run-if-empty strip -s
+
+echo "Re-indexing static libraries with ranlib..."
+find -L ${dir} -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-archive' | \
+    awk -F: '{print $1}' | xargs -n1 --no-run-if-empty ranlib
 
 echo "After: $(du -hs ${dir})"
 FILE5

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -146,6 +146,8 @@ dir=$(realpath ${1})
 
 [ -d "${dir}" ] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
+echo "Before: $(du -hs ${dir})"
+
 # ref: https://spack.readthedocs.io/en/latest/containers.html
 find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
@@ -153,6 +155,7 @@ find -L ${dir} -type f -exec readlink -f '{}' \; | \
     grep 'x-executable\|x-archive\|x-sharedlib' | \
     awk -F: '{print $1}' | xargs strip -s
 
+echo "After: $(du -hs ${dir})"
 FILE5
 
 
@@ -275,9 +278,10 @@ RUN exec &> >(tee /container/logs/cuda.log) && \
     && rm -f ./cuda_*_linux*.run \
     && cd ${CUDA_HOME} \
     && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
-    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \
+    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
     && remove-cuda-static-libs \
+    && cat README.whered_stuff_go \
     && find ${CUDA_HOME} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && add_conf "\n# CUDA ${CUDA_VERSION}" \
     && add_conf "export CUDA_VERSION=${CUDA_VERSION}" \
@@ -548,6 +552,7 @@ RUN exec &> >(tee /container/logs/oneapi.log) \
     && add_conf "export oneapi_CXX=$(which icpx) && export CXX=\${oneapi_CXX}" \
     && add_conf "export oneapi_F77=$(which ifx) && export F77=\${oneapi_F77}" \
     && add_conf "export oneapi_FC=$(which ifx) && export FC=\${oneapi_FC}" \
+    && strip-binaries ${ONEAPI_INSTALL_PATH} \
     && echo ${LD_LIBRARY_PATH} | tr ':' '\n' | grep ${ONEAPI_INSTALL_PATH} >> /etc/ld.so.conf.d/intel-oneapi.conf \
     && ldconfig --verbose \
     && docker-clean

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -701,7 +701,7 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
            add_conf "export NVHPC_CUDA_STUBDIR=$(find ${NVHPC_CUDA_HOME} -type d -name stubs)" ;\
            add_conf "export LD_LIBRARY_PATH=/usr/lib64:/usr/lib:\${LD_LIBRARY_PATH}" ;\
            for dir in {cuda,math_libs}/${NVHPC_CUDA_VERSION}; do \
-               remove-cuda-static-libs >> README.whered_stuff_go ;\
+               remove-cuda-static-libs ${dir} >> README.whered_stuff_go ;\
            done ;\
        fi \
     && cat README.whered_stuff_go \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -176,6 +176,7 @@ dir=$(realpath ${1})
   && echo "[${BASH_SOURCE[0]}]: Removing redundant static libraries from ${dir}..." \
   || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
+echo "Before: $(du -hs ${dir})"
 while read -r static_lib; do
 
     if [[ ! -f "${static_lib}" ]]; then
@@ -195,6 +196,7 @@ while read -r static_lib; do
         rm -vf ${static_lib}
     fi
 done < <(find ${dir} -readable -type f -name "lib*.a")
+echo "After: $(du -hs ${dir})"
 FILE6
 #!/bin/bash
 
@@ -210,6 +212,8 @@ dir=$(realpath ${1})
 [[ -d "${dir}" ]] \
   && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
   || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+
+echo "Before: $(du -hs ${dir})"
 
 while read -r static_lib; do
 
@@ -230,6 +234,7 @@ while read -r static_lib; do
         rm -vf ${static_lib}
     fi
 done < <(find ${dir} -readable -type f -name "lib*_static.a")
+echo "After: $(du -hs ${dir})"
 FILE7
 
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -252,8 +252,9 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && rm -f ./cuda_*_linux*.run \
     && cd ${CUDA_HOME} \
     && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
-    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \
+    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \&& cat README.whered_stuff_go \
     && rm -rf ${rm_paths} \
+    && find ${CUDA_HOME} -type -f -name "libcu*_static.a" -print0 | xargs -0 --no-run-if-empty rm -vf >> README.whered_stuff_go \
     && find ${CUDA_HOME} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && add_conf "\n# CUDA ${CUDA_VERSION}" \
     && add_conf "export CUDA_VERSION=${CUDA_VERSION}" \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -181,15 +181,6 @@ while read -r static_lib; do
         continue
     fi
 
-    # Check CUDA-stylee libcufoo.so / libcufoo_static.a}
-    shared_lib=${static_lib//'_static.a'/'.so'}
-
-    if [[ -f ${shared_lib} ]]; then
-        shared_lib=$(realpath ${shared_lib})
-        ls -lh ${static_lib} ${shared_lib}
-        rm -vf ${static_lib}
-    fi
-
     # Check typical libfoo.so / libfoo.a}
     shared_lib=${static_lib//'.a'/'.so'}
 
@@ -305,7 +296,8 @@ ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
 RUN exec &> >(tee /container/logs/cuda.log) \
-    && cd /tmp \
+    && cd /tmp && \
+    <<'FILE1' cat > /container/bin/remove-cuda-static-libs && chmod +x /container/bin/* \
     && env \
     && echo "Cuda v${CUDA_VERSION} - runfile installer" \
     && echo "CUDA: https://docs.nvidia.com/cuda/eula/index.html" >> /container/EULAs.txt \
@@ -321,7 +313,7 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
-    && remove-redundant-static-libs ${CUDA_HOME} >> README.whered_stuff_go \
+    && remove-cuda-static-libs ${CUDA_HOME} >> README.whered_stuff_go \
     && cat README.whered_stuff_go \
     && find ${CUDA_HOME} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && add_conf "\n# CUDA ${CUDA_VERSION}" \
@@ -338,6 +330,37 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && echo "${CUDA_STUBDIR}" >> /etc/ld.so.conf.d/cuda*.conf \
     && ldconfig --verbose \
     && docker-clean
+#!/bin/bash
+
+set -eu
+
+if [[ ${#} -ne 1 ]]; then
+    echo "Usage: ${0} <directory path>"
+    exit 1
+fi
+
+dir=$(realpath ${1})
+
+[[ -d "${dir}" ]] \
+  && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
+  || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+
+while read -r static_lib; do
+
+    if [[ ! -f "${static_lib}" ]]; then
+        continue
+    fi
+
+    # Check CUDA-stylee libcufoo.so / libcufoo_static.a}
+    shared_lib=${static_lib//'_static.a'/'.so'}
+
+    if [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
+    fi
+done < <(find ${dir} -readable -type f -name "libcu*.a")
+FILE1
 
 # # A sourceable script to query the CUDA configuration at runtime.
 # # (intended to simplify setting compatibility variables for

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -146,7 +146,7 @@ fi
 
 dir=$(realpath ${1})
 
-[ -d "${dir}" ] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+[[ -d "${dir}" ]] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
 TIMEFORMAT=$'--> Real time: %3R seconds'
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -185,12 +185,14 @@ while read -r static_lib; do
     # Check typical libfoo.so / libfoo.a}
     shared_lib=${static_lib//'.a'/'.so'}
     shared_lib=$(realpath ${shared_lib})
-    if [[ "${static_lib}" != "${shared_lib}" ]]; then
-        if [[ -f ${shared_lib} ]]; then
-            shared_lib=$(realpath ${shared_lib})
-            ls -lh ${static_lib} ${shared_lib}
-            rm -vf ${static_lib}
-        fi
+
+    # in case suffix match fails...
+    if cmp -s ${static_lib} ${shared_lib}; then
+       continue
+    elif [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
     fi
 done < <(find ${dir} -readable -type f -name "lib*.a")
 FILE6
@@ -218,11 +220,14 @@ while read -r static_lib; do
     # Check CUDA/NVHPC-style libcufoo.so / libcufoo_static.a}
     shared_lib=${static_lib//'_static.a'/'.so'}
     shared_lib=$(realpath ${shared_lib})
-    if [[ "${static_lib}" != "${shared_lib}" ]]; then
-        if [[ -f ${shared_lib} ]]; then
-            ls -lh ${static_lib} ${shared_lib}
-            rm -vf ${static_lib}
-        fi
+
+    # in case suffix match fails...
+    if cmp -s ${static_lib} ${shared_lib}; then
+       continue
+    elif [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
     fi
 done < <(find ${dir} -readable -type f -name "lib*_static.a")
 FILE7

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -224,8 +224,8 @@ while read -r static_lib; do
     # Check CUDA/NVHPC-style libcufoo.so / libcufoo_static.a}
     shared_lib=${static_lib}
     shared_lib=${shared_lib//'_static.a'/'.so'}
+    shared_lib=${shared_lib//'_static_nocallback.a'/'.so'}
     shared_lib=$(realpath ${shared_lib})
-
 
     if cmp -s ${static_lib} ${shared_lib}; then
         # in case suffix match fails...
@@ -356,7 +356,7 @@ RUN exec &> >(tee /container/logs/cuda.log) \
             --no-man-page \
     && rm -f ./cuda_*_linux*.run \
     && cd ${CUDA_HOME} \
-    && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
+    && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/ nsightee_plugins/" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
     && remove-cuda-static-libs ${CUDA_HOME} >> README.whered_stuff_go \
@@ -615,7 +615,6 @@ RUN exec &> >(tee /container/logs/oneapi.log) \
     && add_conf "export oneapi_CXX=$(which icpx) && export CXX=\${oneapi_CXX}" \
     && add_conf "export oneapi_F77=$(which ifx) && export F77=\${oneapi_F77}" \
     && add_conf "export oneapi_FC=$(which ifx) && export FC=\${oneapi_FC}" \
-    && strip-binaries ${ONEAPI_INSTALL_PATH} \
     && echo ${LD_LIBRARY_PATH} | tr ':' '\n' | grep ${ONEAPI_INSTALL_PATH} >> /etc/ld.so.conf.d/intel-oneapi.conf \
     && ldconfig --verbose \
     && docker-clean

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -75,9 +75,9 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<'FILE2' cat > /container/bin/docker-clean && \
     <<'FILE3' cat > /container/bin/list-large-directories && \
     <<'FILE4' cat > /container/bin/add_conf && \
-    <<'FILE5' cat > /container/bin/strip-binaries \
-    <<'FILE6' cat > /container/bin/remove-redundant-static-libs \
-    && chmod a+rx /container/bin/* \
+    <<'FILE5' cat > /container/bin/strip-binaries &&\
+    <<'FILE6' cat > /container/bin/remove-redundant-static-libs && \
+    chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
     && ln -s /container/config_env.sh /etc/profile.d/z00-build-env.sh
 #-------------------------------------------------------
@@ -145,7 +145,7 @@ fi
 
 dir=$(realpath ${1})
 
-[ -d "${dir}" ] && echo "Stripping all libraries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+[ -d "${dir}" ] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
 TIMEFORMAT=$'--> Real time: %3R seconds'
 
@@ -155,7 +155,7 @@ echo "Before: $(du -hs ${dir})"
 time find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
-    grep 'x-archive\|x-sharedlib' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
     awk -F: '{print $1}' | xargs --no-run-if-empty strip --strip-debug --preserve-dates
 
 echo "After: $(du -hs ${dir})"

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<'FILE4' cat > /container/bin/add_conf && \
     <<'FILE5' cat > /container/bin/strip-binaries &&\
     <<'FILE6' cat > /container/bin/remove-redundant-static-libs && \
+    <<'FILE7' cat > /container/bin/remove-cuda-static-libs && \
     chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
     && ln -s /container/config_env.sh /etc/profile.d/z00-build-env.sh
@@ -191,6 +192,37 @@ while read -r static_lib; do
     fi
 done < <(find ${dir} -readable -type f -name "lib*.a")
 FILE6
+#!/bin/bash
+
+set -eu
+
+if [[ ${#} -ne 1 ]]; then
+    echo "Usage: ${0} <directory path>"
+    exit 1
+fi
+
+dir=$(realpath ${1})
+
+[[ -d "${dir}" ]] \
+  && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
+  || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+
+while read -r static_lib; do
+
+    if [[ ! -f "${static_lib}" ]]; then
+        continue
+    fi
+
+    # Check CUDA/NVHPC-style libcufoo.so / libcufoo_static.a}
+    shared_lib=${static_lib//'_static.a'/'.so'}
+
+    if [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib}
+    fi
+done < <(find ${dir} -readable -type f -name "lib*.a")
+FILE7
 
 
 # Initialize the base OS; whether it is a RHEL, SUSE, or Ubuntu variant to provide
@@ -296,8 +328,7 @@ ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
 RUN exec &> >(tee /container/logs/cuda.log) \
-    && cd /tmp && \
-    <<'FILE1' cat > /container/bin/remove-cuda-static-libs && chmod +x /container/bin/* \
+    && cd /tmp \
     && env \
     && echo "Cuda v${CUDA_VERSION} - runfile installer" \
     && echo "CUDA: https://docs.nvidia.com/cuda/eula/index.html" >> /container/EULAs.txt \
@@ -330,37 +361,6 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && echo "${CUDA_STUBDIR}" >> /etc/ld.so.conf.d/cuda*.conf \
     && ldconfig --verbose \
     && docker-clean
-#!/bin/bash
-
-set -eu
-
-if [[ ${#} -ne 1 ]]; then
-    echo "Usage: ${0} <directory path>"
-    exit 1
-fi
-
-dir=$(realpath ${1})
-
-[[ -d "${dir}" ]] \
-  && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
-  || { echo "ERROR: no such directory: ${dir}"; exit 1; }
-
-while read -r static_lib; do
-
-    if [[ ! -f "${static_lib}" ]]; then
-        continue
-    fi
-
-    # Check CUDA-stylee libcufoo.so / libcufoo_static.a}
-    shared_lib=${static_lib//'_static.a'/'.so'}
-
-    if [[ -f ${shared_lib} ]]; then
-        shared_lib=$(realpath ${shared_lib})
-        ls -lh ${static_lib} ${shared_lib}
-        rm -vf ${static_lib}
-    fi
-done < <(find ${dir} -readable -type f -name "libcu*.a")
-FILE1
 
 # # A sourceable script to query the CUDA configuration at runtime.
 # # (intended to simplify setting compatibility variables for
@@ -701,8 +701,7 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
            add_conf "export NVHPC_CUDA_STUBDIR=$(find ${NVHPC_CUDA_HOME} -type d -name stubs)" ;\
            add_conf "export LD_LIBRARY_PATH=/usr/lib64:/usr/lib:\${LD_LIBRARY_PATH}" ;\
            for dir in {cuda,math_libs}/${NVHPC_CUDA_VERSION}; do \
-               dir=$(realpath ${dir}) ;\
-               find ${dir} -type f -name "lib*_static.a" -print0 | xargs -0 -n1 --no-run-if-empty rm -vf >> README.whered_stuff_go ;\
+               remove-cuda-static-libs >> README.whered_stuff_go ;\
            done ;\
        fi \
     && find ${NVCOMPILERS} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -601,7 +601,7 @@ RUN exec &> >(tee /container/logs/oneapi.log) \
     && curl --retry 3 --retry-delay 5 -s ${ONEAPI_CC_URL} -o cpp-installer.sh && ls -ltrh cpp-installer.sh && chmod +x ./cpp-installer.sh && ./cpp-installer.sh ${installer_opts} && rm -rf cpp-installer.sh \
     && curl --retry 3 --retry-delay 5 -s ${ONEAPI_FC_URL} -o fortran-installer.sh && ls -ltrh fortran-installer.sh && chmod +x ./fortran-installer.sh && ./fortran-installer.sh ${installer_opts} && rm -rf fortran-installer.sh \
     && cd ${ONEAPI_INSTALL_PATH} \
-    && rm_paths="mpi debugger tbb conda_channel compiler/*/linux/lib/oclfpga /opt/intel" \
+    && rm_paths="mpi debugger conda_channel compiler/*/linux/lib/oclfpga /opt/intel" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \
     && rm -rf ${rm_paths} /tmp/intel_installers /var/intel \
     && add_conf "\n# Intel OneAPI compilers" \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -146,17 +146,19 @@ dir=$(realpath ${1})
 
 [ -d "${dir}" ] && echo "Stripping all libraries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
+TIMEFORMAT=$'--> Real time: %3R seconds'
+
 echo "Before: $(du -hs ${dir})"
 
 # ref: https://spack.readthedocs.io/en/latest/containers.html
-find -L ${dir} -type f -exec readlink -f '{}' \; | \
+time find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-archive\|x-sharedlib' | \
     awk -F: '{print $1}' | xargs --no-run-if-empty strip -s
 
 echo "Re-indexing static libraries with ranlib..."
-find -L ${dir} -type f -exec readlink -f '{}' \; | \
+time find -L ${dir} -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-archive' | \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -184,11 +184,13 @@ while read -r static_lib; do
 
     # Check typical libfoo.so / libfoo.a}
     shared_lib=${static_lib//'.a'/'.so'}
-
-    if [[ -f ${shared_lib} ]]; then
-        shared_lib=$(realpath ${shared_lib})
-        ls -lh ${static_lib} ${shared_lib}
-        rm -vf ${static_lib}
+    shared_lib=$(realpath ${shared_lib})
+    if [[ "${static_lib}" != "${shared_lib}" ]]; then
+        if [[ -f ${shared_lib} ]]; then
+            shared_lib=$(realpath ${shared_lib})
+            ls -lh ${static_lib} ${shared_lib}
+            rm -vf ${static_lib}
+        fi
     fi
 done < <(find ${dir} -readable -type f -name "lib*.a")
 FILE6
@@ -204,7 +206,7 @@ fi
 dir=$(realpath ${1})
 
 [[ -d "${dir}" ]] \
-  && echo "[${BASH_SOURCE[0]}]: Removing larger, redundant CUDA toolkit static libraries from ${dir}..." \
+  && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
   || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
 while read -r static_lib; do
@@ -215,13 +217,14 @@ while read -r static_lib; do
 
     # Check CUDA/NVHPC-style libcufoo.so / libcufoo_static.a}
     shared_lib=${static_lib//'_static.a'/'.so'}
-
-    if [[ -f ${shared_lib} ]]; then
-        shared_lib=$(realpath ${shared_lib})
-        ls -lh ${static_lib} ${shared_lib}
-        rm -vf ${static_lib}
+    shared_lib=$(realpath ${shared_lib})
+    if [[ "${static_lib}" != "${shared_lib}" ]]; then
+        if [[ -f ${shared_lib} ]]; then
+            ls -lh ${static_lib} ${shared_lib}
+            rm -vf ${static_lib}
+        fi
     fi
-done < <(find ${dir} -readable -type f -size +10M -name "lib*.a")
+done < <(find ${dir} -readable -type f -name "lib*_static.a")
 FILE7
 
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -135,6 +135,8 @@ echo -e "${1}" >> /container/config_env.sh
 FILE4
 #!/bin/bash
 
+set -eu
+
 if [ ${#} -ne 1 ]; then
     echo "Usage: ${0} <directory path>"
     exit 1

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -177,6 +177,10 @@ dir=$(realpath ${1})
 
 while read -r static_lib; do
 
+    if [[ ! -f "${static_lib}" ]]; then
+        continue
+    fi
+
     # Check CUDA-stylee libcufoo.so / libcufoo_static.a}
     shared_lib=${static_lib//'_static.a'/'.so'}
 
@@ -194,7 +198,7 @@ while read -r static_lib; do
         ls -lh ${static_lib} ${shared_lib}
         rm -vf ${static_lib}
     fi
-done < <(find ${dir} -type f -name "lib*.a")
+done < <(find ${dir} -readable -type f -name "lib*.a")
 FILE6
 
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -259,7 +259,7 @@ ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
 RUN exec &> >(tee /container/logs/cuda.log) && \
-    <<'FILE1' cat > /container/bin/remove-cuda-static-libs && \
+    <<'FILE1' cat > /container/bin/remove-cuda-static-libs \
     && chmod +x /container/bin/* \
     && cd /tmp \
     && env \
@@ -297,7 +297,6 @@ RUN exec &> >(tee /container/logs/cuda.log) && \
 echo "[${BASH_SOURCE[0]}]: Removing CUDA Toolkit static libraries when a suitable shared library exists..."
 
 while read -r static_lib; do
-
 
     shared_lib=${static_lib//'_static.a'/'.so'}
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -679,7 +679,7 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
     && source /container/config_env.sh \
     && cd ${NVCOMPILERS}/${NVARCH}/${NVHPC_VERSION} \
     && rm_paths="comm_libs profilers" \
-    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \
+    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
     && NVHPC_CUDA_VERSION=$(cd ${NVCOMPILERS}/${NVARCH}/${NVHPC_VERSION}/cuda/ && ls * -d | grep -E '[0-9]+\.[0-9]+$') \
     && echo -e "\nNVHPC-Provided CUDA: ${NVHPC_CUDA_VERSION}" \
@@ -704,6 +704,7 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
                remove-cuda-static-libs >> README.whered_stuff_go ;\
            done ;\
        fi \
+    && cat README.whered_stuff_go \
     && find ${NVCOMPILERS} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && echo "Configuring ld.so.conf.d..." \
     && echo "${NVHPC_INSTALL_DIR}/$(uname -s)_$(uname -m)/${NVHPC_VERSION}/compilers/lib" >> /etc/ld.so.conf.d/nvhpc.conf \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -204,7 +204,7 @@ fi
 dir=$(realpath ${1})
 
 [[ -d "${dir}" ]] \
-  && echo "[${BASH_SOURCE[0]}]: Removing redundant CUDA toolkit static libraries from ${dir}..." \
+  && echo "[${BASH_SOURCE[0]}]: Removing larger, redundant CUDA toolkit static libraries from ${dir}..." \
   || { echo "ERROR: no such directory: ${dir}"; exit 1; }
 
 while read -r static_lib; do
@@ -221,7 +221,7 @@ while read -r static_lib; do
         ls -lh ${static_lib} ${shared_lib}
         rm -vf ${static_lib}
     fi
-done < <(find ${dir} -readable -type f -name "lib*.a")
+done < <(find ${dir} -readable -type f -size +10M -name "lib*.a")
 FILE7
 
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -258,7 +258,9 @@ ARG CUDA_VERSION="12.9"
 ARG CUDA_INSTALLER_URL="https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run"
 ARG CUDA_HOME="/container/cuda/${CUDA_VERSION}"
 ENV CUDA_HOME="${CUDA_HOME}"
-RUN exec &> >(tee /container/logs/cuda.log) \
+RUN exec &> >(tee /container/logs/cuda.log) && \
+    <<'FILE1' cat > /container/bin/remove-cuda-static-libs && \
+    && chmod +x /container/bin/* \
     && cd /tmp \
     && env \
     && echo "Cuda v${CUDA_VERSION} - runfile installer" \
@@ -273,9 +275,9 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && rm -f ./cuda_*_linux*.run \
     && cd ${CUDA_HOME} \
     && rm_paths="nsight-*/ extras/ bin/nsys* bin/nsight* libnvvp/" \
-    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \&& cat README.whered_stuff_go \
+    && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) && cat README.whered_stuff_go \
     && rm -rf ${rm_paths} \
-    && find ${CUDA_HOME} -type -f -name "libcu*_static.a" -print0 | xargs -0 --no-run-if-empty rm -vf >> README.whered_stuff_go \
+    && remove-cuda-static-libs \
     && find ${CUDA_HOME} ! -readable -print0 | xargs -0 --no-run-if-empty rm -vf \
     && add_conf "\n# CUDA ${CUDA_VERSION}" \
     && add_conf "export CUDA_VERSION=${CUDA_VERSION}" \
@@ -291,39 +293,56 @@ RUN exec &> >(tee /container/logs/cuda.log) \
     && echo "${CUDA_STUBDIR}" >> /etc/ld.so.conf.d/cuda*.conf \
     && ldconfig --verbose \
     && docker-clean
-
-# A sourceable script to query the CUDA configuration at runtime.
-# (intended to simplify setting compatibility variables for
-# testing on hosts without a CUDA driver.)
-RUN cat <<'EOF' > ${CUDA_HOME}/cuda-host-config.sh
 #!/bin/bash
-echo "[${BASH_SOURCE[0]}]: Checking host GPU capabilities..."
+echo "[${BASH_SOURCE[0]}]: Removing CUDA Toolkit static libraries when a suitable shared library exists..."
 
-nvidia-smi 2>/dev/null && found_gpu=true || found_gpu=false
+while read -r static_lib; do
 
-# quick return when a GPU is found
-if [ "${found_gpu}" = true ]; then
-    echo "Found a GPU..."
-    exit 0
-else
-    echo "No GPU Found..."
-fi
 
-# otherwise,
-if [ -d "${CUDA_STUBDIR}" ]; then
-    find ${CUDA_STUBDIR} -name "libnvidia-ml.so.*" | xargs --no-run-if-empty rm -v
-fi
+    shared_lib=${static_lib//'_static.a'/'.so'}
 
-echo "Disabling CUDA-Aware MPI Features..."
-case "${MPI_FAMILY}" in
-    "openmpi")
-        export OMPI_MCA_opal_cuda_support=false
-        ;;
-    "mpich")
-        export MPIR_CVAR_ENABLE_GPU=0
-        ;;
-esac
-EOF
+    if [[ -f ${shared_lib} ]]; then
+        shared_lib=$(realpath ${shared_lib})
+        ls -lh ${static_lib} ${shared_lib}
+        rm -vf ${static_lib} >> README.whered_stuff_go
+        #ln -sf ${shared_lib} ${static_lib}
+    fi
+
+done < <(find ${CUDA_HOME} -type f -name "lib*_static.a")
+FILE1
+
+# # A sourceable script to query the CUDA configuration at runtime.
+# # (intended to simplify setting compatibility variables for
+# # testing on hosts without a CUDA driver.)
+# RUN cat <<'EOF' > ${CUDA_HOME}/cuda-host-config.sh
+# #!/bin/bash
+# echo "[${BASH_SOURCE[0]}]: Checking host GPU capabilities..."
+
+# nvidia-smi 2>/dev/null && found_gpu=true || found_gpu=false
+
+# # quick return when a GPU is found
+# if [ "${found_gpu}" = true ]; then
+#     echo "Found a GPU..."
+#     exit 0
+# else
+#     echo "No GPU Found..."
+# fi
+
+# # otherwise,
+# if [ -d "${CUDA_STUBDIR}" ]; then
+#     find ${CUDA_STUBDIR} -name "libnvidia-ml.so.*" | xargs --no-run-if-empty rm -v
+# fi
+
+# echo "Disabling CUDA-Aware MPI Features..."
+# case "${MPI_FAMILY}" in
+#     "openmpi")
+#         export OMPI_MCA_opal_cuda_support=false
+#         ;;
+#     "mpich")
+#         export MPIR_CVAR_ENABLE_GPU=0
+#         ;;
+# esac
+# EOF
 
 LABEL cuda="${CUDA_VERSION}"
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -187,9 +187,9 @@ while read -r static_lib; do
     shared_lib=${static_lib//'.a'/'.so'}
     shared_lib=$(realpath ${shared_lib})
 
-    # in case suffix match fails...
     if cmp -s ${static_lib} ${shared_lib}; then
-       continue
+        # in case suffix match fails...
+        continue
     elif [[ -f ${shared_lib} ]]; then
         shared_lib=$(realpath ${shared_lib})
         ls -lh ${static_lib} ${shared_lib}
@@ -222,18 +222,20 @@ while read -r static_lib; do
     fi
 
     # Check CUDA/NVHPC-style libcufoo.so / libcufoo_static.a}
-    shared_lib=${static_lib//'_static.a'/'.so'}
+    shared_lib=${static_lib}
+    shared_lib=${shared_lib//'_static.a'/'.so'}
     shared_lib=$(realpath ${shared_lib})
 
-    # in case suffix match fails...
+
     if cmp -s ${static_lib} ${shared_lib}; then
-       continue
+        # in case suffix match fails...
+        continue
     elif [[ -f ${shared_lib} ]]; then
         shared_lib=$(realpath ${shared_lib})
         ls -lh ${static_lib} ${shared_lib}
         rm -vf ${static_lib}
     fi
-done < <(find ${dir} -readable -type f -name "lib*_static.a")
+done < <(find ${dir} -readable -type f -name "lib*_static*.a")
 echo "After: $(du -hs ${dir})"
 FILE7
 

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -75,6 +75,7 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<'FILE2' cat > /container/bin/docker-clean && \
     <<'FILE3' cat > /container/bin/list-large-directories && \
     <<'FILE4' cat > /container/bin/add_conf \
+    <<'FILE5' cat > /container/bin/strip-binaries \
     && chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
     && ln -s /container/config_env.sh /etc/profile.d/z00-build-env.sh
@@ -132,7 +133,25 @@ fi
 
 echo -e "${1}" >> /container/config_env.sh
 FILE4
+#!/bin/bash
 
+if [ ${#} -ne 1 ]; then
+    echo "Usage: ${0} <directory path>"
+    exit 1
+fi
+
+dir=$(realpath ${1})
+
+[ -d "${dir}" ] && echo "Stripping all binaries in ${dir}..." || { echo "ERROR: no such directory: ${dir}"; exit 1; }
+
+# ref: https://spack.readthedocs.io/en/latest/containers.html
+find -L ${dir} -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs strip -s
+
+FILE5
 
 
 # Initialize the base OS; whether it is a RHEL, SUSE, or Ubuntu variant to provide


### PR DESCRIPTION
This implements some more agressive size shrinking:

- Strip debug sympols from `oneapi` installation.
- Removing large (>10MiB) `libcufoo_static.a` files when `libcufoo.so` exists