### PR TITLE
June refresh

### DIFF
--- a/.github/workflows/build-hpc-development-image.yaml
+++ b/.github/workflows/build-hpc-development-image.yaml
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Check out Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
           fetch-depth: 0
@@ -149,20 +149,20 @@ jobs:
           which nvidia-smi 2>/dev/null && nvidia-smi 2>/dev/null || echo "nvidia-smi not found."
 
       - name: Login to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: benjaminkirk
           password: ${{ secrets.dockerhub_token }}
 
       - name: Set up Docker BuildX (local)
         if: ${{ inputs.buildx_endpoint == '' && inputs.buildx_cloud == false }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: ${{ inputs.arch == 'x86_64' && 'linux/amd64' || 'linux/arm64' }}
 
       - name: Set up Docker BuildX (remote)
         if: ${{ inputs.buildx_endpoint != '' && inputs.buildx_cloud == false }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: ${{ inputs.arch == 'x86_64' && 'linux/amd64' || 'linux/arm64' }}
           driver: ${{ inputs.buildx_driver }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: Set up Docker BuildX (cloud)
         if: ${{ inputs.buildx_cloud }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: ${{ inputs.arch == 'x86_64' && 'linux/amd64' || 'linux/arm64' }}
           driver: cloud
@@ -238,12 +238,12 @@ jobs:
 
       - name: Extract Docker image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.CI_REPO }}
 
       - name: BaseOS + Toolkits + Compiler + MPI Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           load: false
@@ -324,7 +324,7 @@ jobs:
       #----------------------------------------------
       - name: Publish Image
         if: ${{ inputs.publish && inputs.test }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           DOCKER_BUILD_SUMMARY: false
         with:

--- a/.github/workflows/conda-build.yaml
+++ b/.github/workflows/conda-build.yaml
@@ -30,12 +30,12 @@ jobs:
         shell: bash -elo pipefail {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           fetch-depth: 0
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: demo-github-actions
           environment-file: conda.yaml

--- a/.github/workflows/conda-build.yaml
+++ b/.github/workflows/conda-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       hello_world:
-        description: 'Build Simple OpenMP Hello World'
+        description: "Build Simple OpenMP Hello World"
         type: boolean
         default: true
   push:
@@ -14,8 +14,7 @@ on:
   schedule:
     # run at 2:42 UTC every Saturday
     # ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule
-    - cron: '42 2 * * 6'
-
+    - cron: "42 2 * * 6"
 
 jobs:
   build-from-conda-env:
@@ -32,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: "true"
           fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v4

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -78,7 +78,7 @@ jobs:
           export CC CXX FC F77 CFLAGS CXXFLAGS FCFLAGS F77FLAGS CPPFLAGS
           mpicc --version 2>/dev/null || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           fetch-depth: 0

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -4,29 +4,29 @@ on:
   workflow_dispatch:
     inputs:
       hello_world:
-        description: 'Build Simple MPI Hello World'
+        description: "Build Simple MPI Hello World"
         type: boolean
         default: true
 
       dart:
-        description: 'Build Simple Dart Example'
+        description: "Build Simple Dart Example"
         type: boolean
         default: true
       dart_version:
-        description: 'DART Release Version'
+        description: "DART Release Version"
         required: true
         type: string
-        default: 'v11.8.8'
+        default: "v11.8.8"
 
       kokkos:
-        description: 'Build Simple Kokkos Example'
+        description: "Build Simple Kokkos Example"
         type: boolean
         default: false
       kokkos_version:
-        description: 'Kokkos Release Version'
+        description: "Kokkos Release Version"
         required: true
         type: string
-        default: '4.5.01'
+        default: "4.5.01"
 
   push:
     branches:
@@ -38,11 +38,11 @@ jobs:
       fail-fast: true
       matrix:
         compiler: [nvhpc, oneapi, aocc, gcc12, gcc13]
-        mpi:      [mpich, openmpi]
+        mpi: [mpich, openmpi]
 
         include:
           - mpi: openmpi
-            extra_mpiexec_args: '--allow-run-as-root'
+            extra_mpiexec_args: "--allow-run-as-root"
 
     name: Build Inside Container
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
         shell: bash -elo pipefail {0}
 
     container:
-      image:  benjaminkirk/cisldev-almalinux9-${{ matrix.compiler }}-${{ matrix.mpi }}:latest
+      image: benjaminkirk/cisldev-almalinux9-${{ matrix.compiler }}-${{ matrix.mpi }}:latest
 
     steps:
       - name: Interrogate Environment
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: "true"
           fetch-depth: 0
 
       - name: List Source Tree

--- a/.github/workflows/cron-clean-action-log.yaml
+++ b/.github/workflows/cron-clean-action-log.yaml
@@ -5,7 +5,7 @@ on:
   schedule:
     # run at 3:43 UTC 11th of each month
     # ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule
-    - cron: '43 3 11 * *'
+    - cron: "43 3 11 * *"
 
 jobs:
   delete-old-actions:

--- a/.github/workflows/cron-clean-action-log.yaml
+++ b/.github/workflows/cron-clean-action-log.yaml
@@ -11,7 +11,7 @@ jobs:
   delete-old-actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: yanovation/delete-old-actions@v1
         with:
           token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}

--- a/.github/workflows/derived-containers.yaml
+++ b/.github/workflows/derived-containers.yaml
@@ -3,7 +3,7 @@ name: Build Derived Container Images
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ['Container Build']
+    workflows: ["Container Build"]
     types: [completed]
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         compiler: [gcc12]
-        mpi:      [openmpi]
+        mpi: [openmpi]
 
     name: Build Inside Container
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: "true"
           fetch-depth: 0
 
       - name: Interrogate Environment

--- a/.github/workflows/derived-containers.yaml
+++ b/.github/workflows/derived-containers.yaml
@@ -21,7 +21,7 @@ jobs:
         shell: bash -elo pipefail {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
           lscpu
 
       - name: Set up Docker BuildX
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
 
@@ -48,7 +48,7 @@ jobs:
           docker buildx du
 
       - name: Build My Container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: false
           tags: demorepo/myapp-${{ matrix.compiler }}-${{ matrix.mpi }}:latest

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 24
       matrix:
         compiler: [gcc, oneapi, nvhpc, aocc]
-        os: [almalinux10, noble, resolute, leap]
+        os: [almalinux10, noble, leap]
         mpi: [openmpi, mpich]
 
         include:

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -124,7 +124,7 @@ jobs:
       image: benjaminkirk/gh-ci-x86_64:${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.mpi }}-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: "true"
           fetch-depth: 0

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -39,9 +39,9 @@ jobs:
           - compiler: oneapi
             compiler_build_args: |
               COMPILER_FAMILY=oneapi
-              ONEAPI_VERSION=2025.3.2
-              ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0d61d48a-4fe8-4cb2-bd9d-94d2c19c6227/intel-dpcpp-cpp-compiler-2025.3.2.26_offline.sh
-              ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3e53d136-2870-4836-adb1-892b558fa34a/intel-fortran-compiler-2025.3.2.25_offline.sh
+              ONEAPI_VERSION=2026.0.0
+              ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e2f4cda3-8891-4d0e-bf60-00d19c4e3e27/intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh
+              ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/176ca159-bee8-44f2-9164-db26f95de382/intel-fortran-compiler-2026.0.0.573_offline.sh
 
           - compiler: aocc
             compiler_build_args: |

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -51,8 +51,8 @@ jobs:
             compiler_build_args: |
               COMPILER_FAMILY=nvhpc
               MARCH_FLAGS=-march=x86-64-v3
-              NVHPC_VERSION=26.1
-              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.1/nvhpc_2026_261_Linux_x86_64_cuda_multi.tar.gz
+              NVHPC_VERSION=26.5
+              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.5/nvhpc_2026_265_Linux_x86_64_cuda_multi.tar.gz
 
           # - compiler: clang
           #   compiler_build_args: |
@@ -69,7 +69,7 @@ jobs:
           - mpi: mpich
             mpi_build_args: |
               MPI_FAMILY=mpich
-              MPICH_VERSION=5.0.0
+              MPICH_VERSION=5.0.1
 
     # (use a cloud builder for clang -- too resource intensive for free GHA runners)
     #      buildx_cloud: ${{ matrix.compiler == "clang" }}
@@ -90,13 +90,13 @@ jobs:
       test: true
       publish: true
       extra_build_args: |
-        HDF5_VERSION=1.12.3
-        HDF5_URL=https://github.com/HDFGroup/hdf5/releases/download/hdf5-1_12_3/hdf5-1_12_3.tar.gz
-        NETCDF_C_VERSION=4.9.3
-        NETCDF_FORTRAN_VERSION=4.6.2
+        HDF5_VERSION=1.14.5
+        HDF5_URL=https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.5/hdf5-1.14.5.tar.gz
+        NETCDF_C_VERSION=4.10.0
+        NETCDF_FORTRAN_VERSION=4.6.3
         PNETCDF_VERSION=1.14.1
-        PIO_VERSION=2.6.6
-        PIO_TAG=pio2_6_6
+        PIO_VERSION=2.7.0
+        PIO_TAG=pio2_7_0
         FFTW_VERSION=3.3.10
         HEFFTE_VERSION=2.4.1
 

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -50,7 +50,7 @@ jobs:
           - compiler: nvhpc
             compiler_build_args: |
               COMPILER_FAMILY=nvhpc
-              MARCH_FLAGS=-march=x86-64-v3
+              MARCH_FLAGS=-tp=x86-64-v3
               NVHPC_VERSION=26.5
               NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.5/nvhpc_2026_265_Linux_x86_64_cuda_multi.tar.gz
 
@@ -159,7 +159,7 @@ jobs:
       - name: MPI+OpenMP Hello World
         run: |
           mpicxx -o ./hello_world_mpi ./scripts/hello_world_mpi.cxx -fopenmp
-          ldd ./hello_world_mpi
+          report_cpu_features ./hello_world_mpi
           export OMP_NUM_THREADS=2
           export OMPI_MCA_opal_cuda_support=false
           export MPIR_CVAR_ENABLE_GPU=0

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -95,8 +95,8 @@ jobs:
         NETCDF_C_VERSION=4.10.0
         NETCDF_FORTRAN_VERSION=4.6.3
         PNETCDF_VERSION=1.14.1
-        PIO_VERSION=2.7.0
-        PIO_TAG=pio2_7_0
+        PIO_VERSION=2.6.7
+        PIO_TAG=pio2_6_7
         FFTW_VERSION=3.3.10
         HEFFTE_VERSION=2.4.1
 

--- a/.github/workflows/devel-build-images.yaml
+++ b/.github/workflows/devel-build-images.yaml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 24
       matrix:
         compiler: [gcc, oneapi, nvhpc, aocc]
-        os: [almalinux10, noble, leap]
+        os: [almalinux10, noble, resolute, leap]
         mpi: [openmpi, mpich]
 
         include:

--- a/.github/workflows/dial-an-image.yaml
+++ b/.github/workflows/dial-an-image.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       os:
-        description: 'Base OS'
+        description: "Base OS"
         type: choice
         required: true
         default: almalinux9
@@ -17,7 +17,7 @@ on:
           - noble
 
       arch:
-        description: 'CPU Architecture'
+        description: "CPU Architecture"
         type: choice
         required: true
         default: x86_64
@@ -26,13 +26,13 @@ on:
           - aarch64
 
       conda:
-        description: 'Include Conda (Miniforge)'
+        description: "Include Conda (Miniforge)"
         type: boolean
         required: false
         default: true
 
       compiler:
-        description: 'Compiler'
+        description: "Compiler"
         type: choice
         required: true
         default: os-gcc
@@ -45,13 +45,13 @@ on:
           - clang
 
       cuda:
-        description: 'Include CUDA'
+        description: "Include CUDA"
         type: boolean
         required: false
         default: false
 
       mpi:
-        description: 'MPI'
+        description: "MPI"
         type: choice
         required: true
         default: openmpi
@@ -61,19 +61,18 @@ on:
           - mpich3
 
       test:
-        description: 'Test Image'
+        description: "Test Image"
         type: boolean
         required: false
         default: true
 
       publish:
-        description: 'Publish Image'
+        description: "Publish Image"
         type: boolean
         required: false
         default: true
 
 jobs:
-
   build-image:
     name: Build
     uses: ./.github/workflows/build-hpc-development-image.yaml
@@ -96,11 +95,6 @@ jobs:
 
     secrets:
       dockerhub_token: ${{ secrets.BENKIRK_DOCKERHUB_TOKEN }}
-
-
-
-
-
 
     #-------------------------------------------------------------------------------
     # old base -> compiler -> MPI excessivness follows, for reference

--- a/.github/workflows/dial-an-image.yaml
+++ b/.github/workflows/dial-an-image.yaml
@@ -106,7 +106,7 @@ jobs:
     # old base -> compiler -> MPI excessivness follows, for reference
     #-------------------------------------------------------------------------------
     #   - name: Base OS
-    #     uses: docker/build-push-action@v6
+    #     uses: docker/build-push-action@v7
     #     with:
     #       push: true
     #       tags: ${{ secrets.BENKIRK_DOCKERHUB_USERNAME }}/gh-ci-${{ inputs.os }}:latest
@@ -135,7 +135,7 @@ jobs:
 
     #   - name: Additional Compiler
     #     if: ${{ inputs.compiler != '<disabled>' }}
-    #     uses: docker/build-push-action@v6
+    #     uses: docker/build-push-action@v7
     #     with:
     #       push: true
     #       tags: ${{ secrets.BENKIRK_DOCKERHUB_USERNAME }}/gh-ci-${{ inputs.os }}-${{ inputs.compiler }}:latest
@@ -164,7 +164,7 @@ jobs:
 
     #   - name: Add MPI
     #     if: ${{ inputs.mpi != '<disabled>' && inputs.compiler != '<disabled>' }}
-    #     uses: docker/build-push-action@v6
+    #     uses: docker/build-push-action@v7
     #     with:
     #       push: true
     #       tags: ${{ secrets.BENKIRK_DOCKERHUB_USERNAME }}/gh-ci-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.mpi }}:latest

--- a/.github/workflows/manually-clean-action-log.yaml
+++ b/.github/workflows/manually-clean-action-log.yaml
@@ -13,7 +13,7 @@ jobs:
   delete-old-actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: yanovation/delete-old-actions@v1
         with:
           token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -79,7 +79,17 @@ jobs:
           - compiler: gcc14
             compiler_build_args: |
               COMPILER_FAMILY=gcc
-              GCC_VERSION=14.2.0
+              GCC_VERSION=14.3.0
+
+          - compiler: gcc15
+            compiler_build_args: |
+              COMPILER_FAMILY=gcc
+              GCC_VERSION=15.3.0
+
+          - compiler: gcc16
+            compiler_build_args: |
+              COMPILER_FAMILY=gcc
+              GCC_VERSION=16.1.0
 
           - compiler: oneapi
             compiler_build_args: |
@@ -99,15 +109,15 @@ jobs:
             compiler_build_args: |
               COMPILER_FAMILY=nvhpc
               MARCH_FLAGS=-march=x86-64-v3
-              NVHPC_VERSION=26.1
-              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.1/nvhpc_2026_261_Linux_x86_64_cuda_multi.tar.gz
+              NVHPC_VERSION=26.5
+              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.5/nvhpc_2026_265_Linux_x86_64_cuda_multi.tar.gz
 
           - compiler: nvhpc
             arch: aarch64
             compiler_build_args: |
               COMPILER_FAMILY=nvhpc
-              NVHPC_VERSION=26.1
-              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.1/nvhpc_2026_261_Linux_aarch64_cuda_multi.tar.gz
+              NVHPC_VERSION=26.5
+              NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.5/nvhpc_2026_265_Linux_aarch64_cuda_multi.tar.gz
 
           # # clang+flang from source always seems to fail on GHA public runners -
           # # 16GB of RAM simply isn't enough for flang as of 20.1.8.
@@ -126,7 +136,7 @@ jobs:
           - mpi: mpich
             mpi_build_args: |
               MPI_FAMILY=mpich
-              MPICH_VERSION=5.0.0
+              MPICH_VERSION=5.0.1
 
           # - mpi: mpich3
           #   mpi_build_args: |
@@ -165,13 +175,13 @@ jobs:
       test: ${{ inputs.test }}
       publish: ${{ inputs.publish }}
       extra_build_args: |
-        HDF5_VERSION=1.12.3
-        HDF5_URL=https://github.com/HDFGroup/hdf5/releases/download/hdf5-1_12_3/hdf5-1_12_3.tar.gz
-        NETCDF_C_VERSION=4.9.3
-        NETCDF_FORTRAN_VERSION=4.6.2
+        HDF5_VERSION=1.14.5
+        HDF5_URL=https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.5/hdf5-1.14.5.tar.gz
+        NETCDF_C_VERSION=4.10.0
+        NETCDF_FORTRAN_VERSION=4.6.3
         PNETCDF_VERSION=1.14.1
-        PIO_VERSION=2.6.6
-        PIO_TAG=pio2_6_6
+        PIO_VERSION=2.7.0
+        PIO_TAG=pio2_7_0
         FFTW_VERSION=3.3.10
         HEFFTE_VERSION=2.4.1
 

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -180,8 +180,8 @@ jobs:
         NETCDF_C_VERSION=4.10.0
         NETCDF_FORTRAN_VERSION=4.6.3
         PNETCDF_VERSION=1.14.1
-        PIO_VERSION=2.7.0
-        PIO_TAG=pio2_7_0
+        PIO_VERSION=2.6.7
+        PIO_TAG=pio2_6_7
         FFTW_VERSION=3.3.10
         HEFFTE_VERSION=2.4.1
 

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -152,10 +152,12 @@ jobs:
             mpi: mpich3
 
           # CUDA 12.9 incompatibilities
-          - compiler: gcc15
-            gpu: cuda
           - compiler: gcc16
             gpu: cuda
+
+          # gcc16 & openmpi 5.0.10 no bueno; reevalute with 5.0.11
+          - compiler: gcc16
+            mpi: openmpi
 
           # - compiler: nvhpc
           #   arch: aarch64

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -14,6 +14,7 @@ on:
           - almalinux10
           - jammy
           - noble
+          - resolute
           - leap
           - tumbleweed
 
@@ -152,6 +153,9 @@ jobs:
             mpi: mpich3
 
           # CUDA 12.9 incompatibilities
+          - compiler: gcc15
+            gpu: cuda
+
           - compiler: gcc16
             gpu: cuda
 

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -108,7 +108,7 @@ jobs:
             arch: x86_64
             compiler_build_args: |
               COMPILER_FAMILY=nvhpc
-              MARCH_FLAGS=-march=x86-64-v3
+              MARCH_FLAGS=-tp=x86-64-v3
               NVHPC_VERSION=26.5
               NVHPC_URL=https://developer.download.nvidia.com/hpc-sdk/26.5/nvhpc_2026_265_Linux_x86_64_cuda_multi.tar.gz
 

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        compiler: [nvhpc, oneapi, aocc, gcc, gcc12, gcc14]
+        compiler: [nvhpc, oneapi, aocc, gcc, gcc12, gcc14, gcc15, gcc16]
         mpi: [openmpi, mpich]
         gpu: [nogpu, cuda]
         arch: [x86_64, aarch64]
@@ -94,9 +94,9 @@ jobs:
           - compiler: oneapi
             compiler_build_args: |
               COMPILER_FAMILY=oneapi
-              ONEAPI_VERSION=2025.3.1
-              ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5adfc398-db78-488c-b98f-78461b3c5760/intel-dpcpp-cpp-compiler-2025.3.1.16_offline.sh
-              ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/724303ca-6927-4327-a560-e0aabb55b010/intel-fortran-compiler-2025.3.1.16_offline.sh
+              ONEAPI_VERSION=2026.0.0
+              ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e2f4cda3-8891-4d0e-bf60-00d19c4e3e27/intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh
+              ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/176ca159-bee8-44f2-9164-db26f95de382/intel-fortran-compiler-2026.0.0.573_offline.sh
 
           - compiler: aocc
             compiler_build_args: |

--- a/.github/workflows/matrix-build-images.yaml
+++ b/.github/workflows/matrix-build-images.yaml
@@ -151,6 +151,12 @@ jobs:
           - arch: aarch64
             mpi: mpich3
 
+          # CUDA 12.9 incompatibilities
+          - compiler: gcc15
+            gpu: cuda
+          - compiler: gcc16
+            gpu: cuda
+
           # - compiler: nvhpc
           #   arch: aarch64
           #   mpi: mpich

--- a/.github/workflows/matrix-smoketest-applications.yaml
+++ b/.github/workflows/matrix-smoketest-applications.yaml
@@ -62,7 +62,7 @@ jobs:
       image: ${{ inputs.docker_repo }}-${{ matrix.arch }}:${{ inputs.os }}-${{ matrix.compiler }}-${{ matrix.mpi }}${{ matrix.gpu == 'cuda' && '-cuda' || '' }}-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: "true"
           fetch-depth: 0

--- a/.github/workflows/matrix-smoketest-applications.yaml
+++ b/.github/workflows/matrix-smoketest-applications.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: MPI+OpenMP Hello World
         run: |
           mpicxx -o ./hello_world_mpi ./scripts/hello_world_mpi.cxx -fopenmp
-          ldd ./hello_world_mpi
+          report_cpu_features ./hello_world_mpi
           export OMP_NUM_THREADS=2
           export OMPI_MCA_opal_cuda_support=false
           export MPIR_CVAR_ENABLE_GPU=0

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT || secrets.BENKIRK_GITHUB_TOKEN }}
 
@@ -86,7 +86,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: success() || failure()
         with:
           name: MegaLinter reports
@@ -98,7 +98,7 @@ jobs:
       # Create pull request if applicable
       # (for now works only on PR from same repository, not from forks)
       - name: Create Pull Request with applied fixes
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         id: cpr
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
@@ -160,7 +160,7 @@ jobs:
         run: sudo chown -Rc $UID .git/
 
       - name: Commit and push applied linter fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
           (

--- a/.github/workflows/trigger-workflows.yaml
+++ b/.github/workflows/trigger-workflows.yaml
@@ -21,7 +21,7 @@ jobs:
         shell: bash -elo pipefail {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: "true"
           fetch-depth: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,14 +124,28 @@ have `include:` build-args.)
   cmake lines). `REQUIRED=ON` is essential — without it CMake treats the standard as a minimum
   and won't downgrade from the compiler's newer (C23) default. It's also global, so it applies
   regardless of c-blosc's per-arch CPU branch.
-- **gcc-16 + OpenMPI: `always_inline` budget error.** GCC 16 fails the build with
-  `inlining failed in call to 'always_inline' 'mca_part_persist_start': --param
-  max-inline-insns-single limit reached` (OpenMPI `part_persist.h`). This is a hard `error:`
-  from the inliner enforcing the `always_inline` contract — there is **no `-W`/`-Wno-error`
-  knob to demote it** (`-Winline` only covers ordinary `inline`). The lever is to raise the
-  budget: a `gcc:1[6-9].`*-scoped guard in the OpenMPI step exports
-  `CFLAGS="--param max-inline-insns-single=20000 ${CFLAGS}"` (`Dockerfile` ~1058). gcc-15
-  OpenMPI builds clean, so the guard is gcc-16-forward only.
+- **gcc-16 + OpenMPI 5.0.10: `always_inline` budget error → combo skipped.** GCC 16 fails the
+  build with `inlining failed in call to 'always_inline' 'mca_part_persist_start': --param
+  max-inline-insns-single limit reached` (OpenMPI `part_persist.h`). It's a hard `error:` from
+  the inliner enforcing the `always_inline` contract — **no `-W`/`-Wno-error` knob demotes it**
+  (`-Winline` only covers ordinary `inline`); the only lever is to raise the budget
+  (`CFLAGS="--param max-inline-insns-single=20000 …"`). The fix lands upstream in OpenMPI
+  5.0.11, so rather than carry the workaround we **exclude `gcc16 + openmpi` in
+  `matrix-build-images.yaml`** (see the `reevaluate with 5.0.11` comment) — gcc-15 OpenMPI and
+  gcc16+mpich build clean. Drop the exclude once OpenMPI is bumped to ≥5.0.11.
+- **nvhpc ignores `-march=`; microarch must be set with `-tp`.** `nvc` does not understand
+  GNU's `-march=x86-64-v3`, so passing it via `MARCH_FLAGS` is a silent no-op and nvc falls
+  back to its auto-detected default `-tp` = the *build runner's* native CPU (e.g. `-tp znver4`
+  → AVX-512). The image then carries instructions the **test/deploy** host may lack → a bare
+  `Illegal instruction` (SIGILL) that looks OS-specific but is really build-vs-run runner
+  roulette. Use nvc's own ABI-level target instead: the nvhpc matrix entry sets
+  `MARCH_FLAGS=-tp=x86-64-v3` (other families keep `-march=…`). Note `nvc -V` prints the
+  *default* `-tp`, not the per-compile one — don't trust it; inspect the binary.
+- **`report_cpu_features [binary]`** (`/container/bin/`, a base_os FILE-heredoc) is the tool
+  for the above: it prints the host's SIMD level and, given an executable, the ISA it
+  *requires* (`readelf -n` note + `objdump` scan for x86 `%zmm` / arm SVE `z*` regs). The
+  hello-world smoke tests (`devel`/`matrix-smoketest` workflows, `containers/test`) call it so
+  an over-built binary is visible *before* the SIGILL. Reusable for any executable.
 - **CUDA 12.9 runfile installer runs its own host-gcc check** ("Failed to verify gcc
   version") that rejects gcc ≥15 — separate from nvcc, and *not* relaxed by the
   `-allow-unsupported-compiler` in `NVCC_PREPEND_FLAGS` (that only affects nvcc compiles).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,12 @@ A version bump = edit `compiler_build_args` / `mpi_build_args` / `extra_build_ar
 two files (library versions like HDF5/NetCDF/PIO live in `extra_build_args`). For NVHPC also
 update the CUDA exclude paths in the Dockerfile (above).
 
+**Matrix gotcha:** a new compiler must be added to the base `compiler:` axis list (not just
+an `include:` entry). An `include:`-only value that matches no base combination can't merge,
+so GitHub creates a single malformed standalone job for it with no `mpi`/`gpu`/`arch` — it
+won't fan out across the matrix. (This is why `gcc15`/`gcc16` are in the base list *and*
+have `include:` build-args.)
+
 ## CI workflows
 
 - `build-hpc-development-image.yaml` — **reusable** build → test → publish; called by the
@@ -84,18 +90,39 @@ update the CUDA exclude paths in the Dockerfile (above).
 
 ## Conventions & gotchas
 
-- **gcc-15 / C23 `-std=gnu17` pattern.** GCC 15 defaults to `-std=gnu23`; several older C
-  libraries (c-blosc, pnetcdf, …) don't compile under C23. The Dockerfile guards these with
-  per-library `case "${COMPILER_FAMILY}:${GCC_VERSION}" in` blocks that prepend
-  `-std=gnu17`. **`nvc` (NVHPC) inherits the host GCC's C-standard default**, so on a distro
-  whose system gcc is 15 (currently `leap`/`tumbleweed`, set at `Dockerfile:293`) nvhpc
-  hits the same C23 errors and must be covered by the same guard — hence the
-  `"gcc:15."*|"nvhpc:"*)` arms at `Dockerfile:1159` (c-blosc) and `:1289` (pnetcdf). If a
-  later C library breaks under nvhpc with *"invalid combination of type specifiers"* or a
-  `bool`/`_Bool` typedef error, add the same arm to that step.
-- Compiler-specific quirks are handled with `case "${COMPILER_FAMILY}" in` (e.g.
-  aocc/clang need `--disable-nonstandard-feature-float16` for HDF5 and a libtool `wl=`
-  patch; nvhpc/clang disable the MPICH f08 interface).
+- **The system gcc is a load-bearing lever.** A distro's *system* gcc drives three things
+  at once: the `os-gcc` compiler family, **nvhpc's host C dialect** (`nvc` inherits the
+  system gcc's default `-std`), and the **CUDA runfile installer's gcc version check**. So
+  keeping a distro's system gcc at a pre-C23 version (≤14) avoids a whole class of breakage.
+  This is why leap is pinned (below) rather than chasing per-library workarounds.
+- **gcc-15 / C23 `-std=gnu17` pattern.** GCC ≥15 defaults to `-std=gnu23`; older C code
+  (c-blosc, pnetcdf, MPICH, ParallelIO's bundled GPTL) breaks under C23 — typically
+  `bool`/`_Bool`/`false`/`true` keyword or `typedef` errors, or "invalid combination of type
+  specifiers". Guarded per-library with `case "${COMPILER_FAMILY}:${GCC_VERSION}" in` blocks
+  that prepend `-std=gnu17`, matched on `"gcc:1[5-9]."*|"gcc:[2-9][0-9]."*` (i.e. gcc ≥15,
+  forward-looking) plus `"nvhpc:"*` as a safety net. These guards are required for the
+  explicit **gcc15/gcc16 source-build** compilers on *any* OS, independent of the leap pin.
+  Sites: `Dockerfile` ~1002 (MPICH5), ~1159 (c-blosc), ~1289 (pnetcdf). If a new C library
+  breaks the same way, add the same arm.
+- **leap base is pinned.** The `opensuse/leap` rolling tag moved to **Leap 16.0**, which
+  ships gcc-15 and dropped the `gcc14` package — that broke nvhpc/leap (C23) and the CUDA
+  install. We pin `FROM docker.io/opensuse/leap:15` (`Dockerfile:53`) and `gcc_v=14`
+  (`Dockerfile:293`, shared `leap|tumbleweed` arm) to keep a pre-C23 system gcc. If leap's
+  system gcc ever must move to ≥15, expect the C23 guards above to start firing for `os-gcc`
+  and `nvhpc` on leap too.
+- **CMake nested sub-projects don't inherit `$CFLAGS`.** Exporting `CFLAGS=-std=gnu17`
+  before `cmake` fixes flat CMake builds (c-blosc), but **not** a bundled sub-project that
+  calls its own `project()` — e.g. PIO's GPTL (`src/gptl/CMakeLists.txt`). Pin the standard
+  via cache instead: `-DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON`
+  (`Dockerfile` PIO step). `REQUIRED=ON` is essential — without it CMake treats the standard
+  as a minimum and won't downgrade from the compiler's newer (C23) default.
+- **CUDA 12.9 runfile installer runs its own host-gcc check** ("Failed to verify gcc
+  version") that rejects gcc ≥15 — separate from nvcc, and *not* relaxed by the
+  `-allow-unsupported-compiler` in `NVCC_PREPEND_FLAGS` (that only affects nvcc compiles).
+  Keep cuda-enabled distros on system gcc ≤14, or pass the installer's `--override` flag.
+- Other compiler-specific quirks use `case "${COMPILER_FAMILY}" in` (e.g. aocc/clang need
+  `--disable-nonstandard-feature-float16` for HDF5 and a libtool `wl=` patch; nvhpc/clang
+  disable the MPICH f08 interface; HDF5 forces its own `-std=c99`, so it's C23-immune).
 - Bloat control is pervasive: `--disable-static --enable-shared`, `install-strip`,
   `docker-clean`, and removal of docs/profilers/static libs. Keep it lean.
 - Spelling/lint via `.cspell.json` and `.mega-linter.yml` (MegaLinter is a separate, often
@@ -108,8 +135,16 @@ gh pr checks <PR#>                       # see which matrix jobs failed
 gh run view --job <job-id> --log         # full job log (use --log-failed for just failures)
 gh run view --job <job-id> --log > out.log && grep -nE 'error:|Error 2' out.log
 gh workflow run dial-an-image.yaml -f …  # rebuild a single variant to reproduce a failure
+# pull ONE job's log while the overall run is still in progress (run-level --log refuses):
+gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs > out.log
+# authoritative job list (the `--json jobs` view can under-report long matrices):
+gh api --paginate "repos/<owner>/<repo>/actions/runs/<run-id>/jobs?per_page=100" -q '.jobs[].name'
 ```
 
-Note: the real compiler error in a failing image build is usually buried mid-log — the
-buildx "failed to solve" tail only echoes the failing RUN recipe, not the error. Fetch the
-full `--log` and grep for `error:` / `Error 2`.
+Notes:
+- The real compiler error in a failing image build is usually buried mid-log — the buildx
+  "failed to solve" tail only echoes the failing RUN recipe, not the error. Fetch the full
+  `--log` and grep for `error:` / `Error 2`.
+- `matrix-build-images.yaml` is `workflow_dispatch`-only (one base-OS per dispatch) and runs
+  in `max-parallel: 16` waves, so jobs appear in batches — a partial job list early in a run
+  is normal, not a dropped matrix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What this project is
+
+A CI/CD system that builds **multi-layer Docker images of HPC software stacks** and
+publishes them to DockerHub (e.g. `ncarcisl/hpcdev-*`, `benjaminkirk/hpcdev-*`). Each image
+is a chosen combination of **compiler × MPI × GPU runtime × Linux distro**, with a common
+set of scientific libraries (HDF5, NetCDF C/Fortran, PnetCDF, ParallelIO, FFTW, HeFFTe)
+built from source on top. Despite the repo name, the substance is the `containers/devenv`
+image and the GitHub Actions matrices that drive it.
+
+## Repository layout
+
+- `containers/devenv/Dockerfile` — **the core**, ~1480 lines, 20+ named stages. Almost all
+  real work and almost every change happens here.
+- `containers/devenv/Makefile` — copies `scripts/` into the build context as `extras/`.
+- `containers/{demo,test,publish}/` — small downstream images: demo app, test runner
+  (OSU micro-benchmarks etc.), and the final publish/SBOM stage.
+- `containers/deploy/ncar-hpc/` — Apptainer/PBS deploy configs for NCAR clusters (Derecho/Casper).
+- `scripts/` — `build_*.sh` for real apps (WRF, CESM, ESMF, PETSc, DART, MPAS, Kokkos, …),
+  `build_common.cfg` (sourced; sets `INSTALL_ROOT`, `STAGE_DIR`), and `hello_world.*` samples.
+- `.github/workflows/` — see CI section below.
+- `.github/actions/{slim-action-runner,docker-cleanup}/` — composite actions to free disk
+  space on GHA runners and prune Docker between stages.
+
+## Dockerfile architecture (`containers/devenv/Dockerfile`)
+
+A PREREQ-arg-selectable multi-stage DAG. Build-args choose which concrete stage backs each
+logical layer:
+
+```
+base_os ──▶ [cuda | rocm]? ──▶ miniforge ──▶ toolkits ──▶ <compiler>
+   ──▶ <mpi> ──▶ iolibs ──▶ mpi-iolibs ──▶ fftlibs ──▶ final
+```
+
+Key selector ARGs (with representative values):
+- `BASE_OS` — `almalinux8/9/10`, `rockylinux8/9/10`, `leap`, `tumbleweed`, `jammy`, `noble`
+  (+ `*-cuda`/`*-rocm` vendor bases).
+- `COMPILER_FAMILY` — `os-gcc` (distro gcc), `gcc` (built from source, `GCC_VERSION`),
+  `oneapi`, `aocc`, `nvhpc`, `clang`.
+- `MPI_FAMILY` — `openmpi`, `mpich` (5.0.x) / `mpich3` (3.4.x).
+- `MINIFORGE_PREREQ`, `TOOLKITS_PREREQ`, `IOLIBS_PREREQ`, `FFTLIBS_PREREQ`, `FINAL_TARGET`
+  — wire the DAG (e.g. `MINIFORGE_PREREQ=cuda` layers conda on the CUDA stage; parallel
+  HDF5/NetCDF are enabled when `IOLIBS_PREREQ=mpi`).
+
+**Environment accumulation:** stages append `export …` lines to `/container/config_env.sh`
+via the `add_conf` helper (PATH, CPATH, LIBRARY_PATH, LD_LIBRARY_PATH, CC/CXX/FC, CFLAGS).
+That file is sourced by every login shell and is the single source of truth for the
+in-image environment. Each library installs to a versioned prefix under `/container/`.
+
+**nvhpc specifics:** installed from the `cuda_multi` tarball; unused CUDA versions are
+dropped at extract time (`tar --exclude='*/cuda/<ver>/*'`) and again via `rm_paths`, and a
+CUDA that matches a separately-installed `CUDA_VERSION` is symlinked rather than duplicated
+(GHA disk is tight). When bumping NVHPC, update both the `NVHPC_URL` and these `<ver>`
+exclude/`rm_paths` strings to the CUDA the new SDK bundles.
+
+## Versions and how to bump them
+
+Defaults live as `ARG`s in the Dockerfile, but the **real, authoritative versions are the
+CI matrices**, which override the ARGs via build-args:
+- `.github/workflows/matrix-build-images.yaml` — full production matrix.
+- `.github/workflows/devel-build-images.yaml` — the PR/dev subset (4 compilers ×
+  {almalinux10, noble, leap} × {openmpi, mpich}) plus an apps smoke-test job.
+
+A version bump = edit `compiler_build_args` / `mpi_build_args` / `extra_build_args` in those
+two files (library versions like HDF5/NetCDF/PIO live in `extra_build_args`). For NVHPC also
+update the CUDA exclude paths in the Dockerfile (above).
+
+## CI workflows
+
+- `build-hpc-development-image.yaml` — **reusable** build → test → publish; called by the
+  others. Builds with `docker/build-push-action`, registry-cache keyed on all build inputs
+  (`…-cache` repo), then a separate publish pass via `containers/publish/Dockerfile`.
+- `matrix-build-images.yaml` — full matrix (compilers × MPI × GPU × arch), production tags.
+- `devel-build-images.yaml` — runs on PRs touching the Dockerfile/scripts; the subset that
+  most PRs (including version bumps) are validated against.
+- `dial-an-image.yaml` — `workflow_dispatch` to build a single hand-picked variant; the
+  fastest way to reproduce/iterate on one failing combination.
+- Also: `container-build.yaml`, `conda-build.yaml`, `derived-containers.yaml`,
+  `matrix-smoketest-applications.yaml`, `trigger-workflows.yaml`, log-cleanup crons,
+  `mega-linter.yml`.
+
+## Conventions & gotchas
+
+- **gcc-15 / C23 `-std=gnu17` pattern.** GCC 15 defaults to `-std=gnu23`; several older C
+  libraries (c-blosc, pnetcdf, …) don't compile under C23. The Dockerfile guards these with
+  per-library `case "${COMPILER_FAMILY}:${GCC_VERSION}" in` blocks that prepend
+  `-std=gnu17`. **`nvc` (NVHPC) inherits the host GCC's C-standard default**, so on a distro
+  whose system gcc is 15 (currently `leap`/`tumbleweed`, set at `Dockerfile:293`) nvhpc
+  hits the same C23 errors and must be covered by the same guard — hence the
+  `"gcc:15."*|"nvhpc:"*)` arms at `Dockerfile:1159` (c-blosc) and `:1289` (pnetcdf). If a
+  later C library breaks under nvhpc with *"invalid combination of type specifiers"* or a
+  `bool`/`_Bool` typedef error, add the same arm to that step.
+- Compiler-specific quirks are handled with `case "${COMPILER_FAMILY}" in` (e.g.
+  aocc/clang need `--disable-nonstandard-feature-float16` for HDF5 and a libtool `wl=`
+  patch; nvhpc/clang disable the MPICH f08 interface).
+- Bloat control is pervasive: `--disable-static --enable-shared`, `install-strip`,
+  `docker-clean`, and removal of docs/profilers/static libs. Keep it lean.
+- Spelling/lint via `.cspell.json` and `.mega-linter.yml` (MegaLinter is a separate, often
+  noisy check — not part of the image build).
+
+## Useful commands
+
+```bash
+gh pr checks <PR#>                       # see which matrix jobs failed
+gh run view --job <job-id> --log         # full job log (use --log-failed for just failures)
+gh run view --job <job-id> --log > out.log && grep -nE 'error:|Error 2' out.log
+gh workflow run dial-an-image.yaml -f …  # rebuild a single variant to reproduce a failure
+```
+
+Note: the real compiler error in a failing image build is usually buried mid-log — the
+buildx "failed to solve" tail only echoes the failing RUN recipe, not the error. Fetch the
+full `--log` and grep for `error:` / `Error 2`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,20 +102,36 @@ have `include:` build-args.)
   that prepend `-std=gnu17`, matched on `"gcc:1[5-9]."*|"gcc:[2-9][0-9]."*` (i.e. gcc ≥15,
   forward-looking) plus `"nvhpc:"*` as a safety net. These guards are required for the
   explicit **gcc15/gcc16 source-build** compilers on *any* OS, independent of the leap pin.
-  Sites: `Dockerfile` ~1002 (MPICH5), ~1159 (c-blosc), ~1289 (pnetcdf). If a new C library
-  breaks the same way, add the same arm.
+  Sites: `Dockerfile` ~1002 (MPICH5), ~1291 (pnetcdf). **c-blosc no longer uses a CFLAGS
+  arm** — it pins the standard via the CMake cache instead (see the CMake bullet below). If
+  a new C library breaks the same way, add the same arm (or the CMake-cache pin if it builds
+  with cmake).
 - **leap base is pinned.** The `opensuse/leap` rolling tag moved to **Leap 16.0**, which
   ships gcc-15 and dropped the `gcc14` package — that broke nvhpc/leap (C23) and the CUDA
   install. We pin `FROM docker.io/opensuse/leap:15` (`Dockerfile:53`) and `gcc_v=14`
   (`Dockerfile:293`, shared `leap|tumbleweed` arm) to keep a pre-C23 system gcc. If leap's
   system gcc ever must move to ≥15, expect the C23 guards above to start firing for `os-gcc`
   and `nvhpc` on leap too.
-- **CMake nested sub-projects don't inherit `$CFLAGS`.** Exporting `CFLAGS=-std=gnu17`
-  before `cmake` fixes flat CMake builds (c-blosc), but **not** a bundled sub-project that
-  calls its own `project()` — e.g. PIO's GPTL (`src/gptl/CMakeLists.txt`). Pin the standard
-  via cache instead: `-DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON`
-  (`Dockerfile` PIO step). `REQUIRED=ON` is essential — without it CMake treats the standard
-  as a minimum and won't downgrade from the compiler's newer (C23) default.
+- **For CMake builds, pin the C standard via cache, not `$CFLAGS`.** Exporting
+  `CFLAGS=-std=gnu17` before `cmake` is unreliable: (a) a bundled sub-project that calls its
+  own `project()` ignores it entirely — e.g. PIO's GPTL (`src/gptl/CMakeLists.txt`); and
+  (b) even for a flat project like **c-blosc** it is *arch-dependent* — c-blosc's CMake only
+  threads the env CFLAGS through on its recognized-CPU (x86 SSE2/AVX2) branch, so on aarch64
+  it logs `Unrecognized system processor aarch64` and compiles `shuffle.c` under the
+  compiler's default (gcc ≥15 → `-std=gnu23` → `'bool' cannot be defined via typedef`). x86_64
+  passed while aarch64 failed for the *same* gcc15/gcc16 build. Fix both with the cache pin:
+  `-DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON` (now on **both** the PIO and c-blosc
+  cmake lines). `REQUIRED=ON` is essential — without it CMake treats the standard as a minimum
+  and won't downgrade from the compiler's newer (C23) default. It's also global, so it applies
+  regardless of c-blosc's per-arch CPU branch.
+- **gcc-16 + OpenMPI: `always_inline` budget error.** GCC 16 fails the build with
+  `inlining failed in call to 'always_inline' 'mca_part_persist_start': --param
+  max-inline-insns-single limit reached` (OpenMPI `part_persist.h`). This is a hard `error:`
+  from the inliner enforcing the `always_inline` contract — there is **no `-W`/`-Wno-error`
+  knob to demote it** (`-Winline` only covers ordinary `inline`). The lever is to raise the
+  budget: a `gcc:1[6-9].`*-scoped guard in the OpenMPI step exports
+  `CFLAGS="--param max-inline-insns-single=20000 ${CFLAGS}"` (`Dockerfile` ~1058). gcc-15
+  OpenMPI builds clean, so the guard is gcc-16-forward only.
 - **CUDA 12.9 runfile installer runs its own host-gcc check** ("Failed to verify gcc
   version") that rejects gcc ≥15 — separate from nvcc, and *not* relaxed by the
   `-allow-unsupported-compiler` in `NVCC_PREPEND_FLAGS` (that only affects nvcc compiles).

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -701,8 +701,8 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
     && echo "downloading ${NVHPC_URL}" \
     && curl --retry 3 --retry-delay 5 -sSL ${NVHPC_URL} | \
         tar zx \
-            --exclude='*/cuda/13.1/*' \
-            --exclude='*/math_libs/13.1/*' \
+            --exclude='*/cuda/13.2/*' \
+            --exclude='*/math_libs/13.2/*' \
             --exclude='*/comm_libs/*' \
             --exclude='*/profilers/*' \
     && export NVHPC_SILENT="true" \
@@ -720,7 +720,7 @@ RUN exec &> >(tee /container/logs/nvhpc.log) \
     && add_conf "export MARCH_FLAGS=\"${MARCH_FLAGS}\"" \
     && source /container/config_env.sh \
     && cd ${NVCOMPILERS}/${NVARCH}/${NVHPC_VERSION} \
-    && rm_paths="comm_libs/ profilers/ cuda/13.1/ math_libs/13.1/" \
+    && rm_paths="comm_libs/ profilers/ cuda/13.2/ math_libs/13.2/" \
     && echo "Removing extra bloat: ${rm_paths}" > README.whered_stuff_go && (du -hs ${rm_paths} >> README.whered_stuff_go || true) \
     && rm -rf ${rm_paths} \
     && NVHPC_CUDA_VERSION=$(cd ${NVCOMPILERS}/${NVARCH}/${NVHPC_VERSION}/cuda/ && ls * -d | grep -E '[0-9]+\.[0-9]+$') \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -1156,7 +1156,7 @@ RUN exec &> >(tee /container/logs/iolibs.log) \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz | tar zx \
     && cd ./c-blosc-${BLOSC_VERSION} \
     && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:15."*) \
+        "gcc:15."*|"nvhpc:"*) \
             export CFLAGS="-std=gnu17 ${CFLAGS}" \
             ;; \
        esac \
@@ -1286,7 +1286,7 @@ RUN exec &> >(tee /container/logs/mpi-iolibs.log) \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://parallel-netcdf.github.io/Release/pnetcdf-${PNETCDF_VERSION}.tar.gz | tar zx \
     && cd ./pnetcdf-${PNETCDF_VERSION} \
     && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:15."*) \
+        "gcc:15."*|"nvhpc:"*) \
             export CFLAGS="-std=gnu17 ${CFLAGS}" \
             ;; \
        esac \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -55,6 +55,7 @@ FROM docker.io/opensuse/tumbleweed AS tumbleweed
 
 FROM ubuntu:jammy AS jammy
 FROM ubuntu:noble AS noble
+FROM ubuntu:resolute AS resolute
 
 # In theory we could not install CUDA or ROCM and instead take a
 # preconfigured vendor image; leaving these here for reference.
@@ -383,6 +384,7 @@ RUN exec &> >(tee /container/logs/base-os.log) \
                 && case "${id_tag}" in \
                     *"|jammy|"*) gcc_v=12 ;; \
                     *"|noble|"*) gcc_v=14 ;; \
+                    *"|resolute|"*) gcc_v=14 ;; \
                    esac \
                 && (echo -e 'y\n' | unminimize) \
                 && apt-get update \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -84,6 +84,7 @@ RUN mkdir -p /container/{bin,extras,logs} && \
     <<'FILE5' cat > /container/bin/strip-binaries &&\
     <<'FILE6' cat > /container/bin/remove-redundant-static-libs && \
     <<'FILE7' cat > /container/bin/remove-cuda-static-libs && \
+    <<'FILE8' cat > /container/bin/report_cpu_features && \
     chmod a+rx /container/bin/* \
     && cat /container/config_env.sh \
     && ln -s /container/config_env.sh /etc/profile.d/z00-build-env.sh
@@ -245,6 +246,71 @@ while read -r static_lib; do
 done < <(find ${dir} -readable -type f -name "lib*_static*.a")
 echo "After: $(du -hs ${dir})"
 FILE7
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# report_cpu_features [executable]
+#
+#  (1) always: report this host's CPU and its microarchitecture (SIMD) features.
+#  (2) optional: given an executable, also report the ISA it REQUIRES, so a
+#      binary built for a newer CPU than the host (a latent SIGILL, e.g. an
+#      nvhpc binary targeting -tp znver4/AVX-512 run on an AVX2-only runner)
+#      is obvious instead of a bare "Illegal instruction".
+#
+#  Works on x86_64 and aarch64; purely informational, never fails the caller.
+#-------------------------------------------------------------------------------
+arch=$(uname -m)
+
+echo "== host: $(uname -mns) =="
+case "${arch}" in
+    x86_64)
+        grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ *//'
+        echo -n "  ISA flags: "
+        grep -m1 flags /proc/cpuinfo | grep -oE 'avx512[a-z]*|avx2|fma|bmi[12]|sse4_[12]' | sort -u | tr '\n' ' '
+        echo
+        ;;
+    aarch64|arm64)
+        grep -m1 -E 'CPU implementer|CPU part' /proc/cpuinfo
+        echo -n "  SIMD: "
+        grep -m1 'Features' /proc/cpuinfo | grep -oE 'asimd|sve[0-9]*|fphp|bf16|i8mm' | sort -u | tr '\n' ' '
+        echo
+        ;;
+    *)
+        echo "  (unhandled arch ${arch})"
+        ;;
+esac
+
+bin="${1:-}"
+[[ -z "${bin}" ]] && exit 0
+if [[ ! -e "${bin}" ]]; then
+    echo "report_cpu_features: no such file: ${bin}" >&2
+    exit 0
+fi
+
+echo "== ${bin} requires =="
+command -v ldd     >/dev/null 2>&1 && { ldd "${bin}" 2>/dev/null || true; }
+command -v readelf >/dev/null 2>&1 \
+    && { readelf -nW "${bin}" 2>/dev/null | grep -iE 'ISA|feature|properties' || echo "  (no GNU ISA-needed note)"; }
+
+if command -v objdump >/dev/null 2>&1; then
+    case "${arch}" in
+        x86_64)
+            if objdump -d "${bin}" 2>/dev/null | grep -qE '%zmm[0-9]+'; then
+                echo "  AVX-512 (zmm) used by binary: YES  (requires an AVX-512 host)"
+            else
+                echo "  AVX-512 (zmm) used by binary: no"
+            fi
+            ;;
+        aarch64|arm64)
+            if objdump -d "${bin}" 2>/dev/null | grep -qE 'z[0-9]+\.[bhsd]'; then
+                echo "  SVE (z-regs) used by binary: YES  (requires an SVE host)"
+            else
+                echo "  SVE (z-regs) used by binary: no"
+            fi
+            ;;
+    esac
+fi
+exit 0
+FILE8
 
 
 #---------------------------------------------------------------------------------

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -290,7 +290,7 @@ RUN exec &> >(tee /container/logs/base-os.log) \
             ;; \
         *"leap|"*|*"tumbleweed|"*) \
                 add_conf 'export PKG_INSTALL_CMD="zypper --gpg-auto-import-keys --non-interactive install"' \
-                && gcc_v=14 \
+                && gcc_v=15 \
                 && sed -i 's/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/g' /etc/zypp/zypp.conf \
                 && zypper --non-interactive refresh \
                 && zypper --non-interactive update \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -386,7 +386,7 @@ RUN exec &> >(tee /container/logs/base-os.log) \
                     *"|noble|"*) gcc_v=14 ;; \
                     *"|resolute|"*) gcc_v=14 ;; \
                    esac \
-                && (echo -e 'y\n' | unminimize) \
+                && (echo -e 'y\n' | unminimize || true) \
                 && apt-get update \
                 && apt-get upgrade \
                 && apt-get autoclean \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -611,9 +611,9 @@ FROM toolkits AS oneapi
 # We'd rather not need that, so add to the system search path
 #
 # Install and remove C++, Fortran one at a time as we go for when disk space is tight, rather than downloading both installers at once.
-ARG ONEAPI_VERSION=2025.3.2
-ARG ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0d61d48a-4fe8-4cb2-bd9d-94d2c19c6227/intel-dpcpp-cpp-compiler-2025.3.2.26_offline.sh
-ARG ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3e53d136-2870-4836-adb1-892b558fa34a/intel-fortran-compiler-2025.3.2.25_offline.sh
+ARG ONEAPI_VERSION=2026.0.0
+ARG ONEAPI_CC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e2f4cda3-8891-4d0e-bf60-00d19c4e3e27/intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh
+ARG ONEAPI_FC_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/176ca159-bee8-44f2-9164-db26f95de382/intel-fortran-compiler-2026.0.0.573_offline.sh
 RUN exec &> >(tee /container/logs/oneapi.log) \
     && echo "Installing Intel-OneAPI" \
     && echo "Intel OneAPI: https://www.intel.com/content/www/us/en/content-details/777700/intel-end-user-license-agreement-for-developer-tools-august-2024.html" >> /container/EULAs.txt \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -1312,6 +1312,11 @@ RUN exec &> >(tee /container/logs/mpi-iolibs.log) \
     && PIO_INSTALL_PATH="/container/parallelio/${PIO_VERSION}" \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://github.com/NCAR/ParallelIO/archive/refs/tags/${PIO_TAG}.tar.gz | tar zx \
     && cd ./*${PIO_TAG}/ && mkdir -p build && cd build \
+    && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
+        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*) \
+            export CFLAGS="-std=gnu17 ${CFLAGS}" \
+            ;; \
+       esac \
     && cmake \
            -Wno-dev \
            -DCMAKE_BUILD_TYPE=MinSizeRel \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -1055,11 +1055,6 @@ RUN exec &> >(tee /container/logs/openmpi.log) \
     && case "${COMPILER_FAMILY}" in \
         "aocc") extra_config_args="--disable-alt-short-float" ;; \
        esac \
-    && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:1[6-9]."*|"gcc:[2-9][0-9]."*) \
-            export CFLAGS="--param max-inline-insns-single=20000 ${CFLAGS}" \
-            ;; \
-       esac \
     && ./configure --help \
     && (./configure \
            --prefix=${OPENMPI_INSTALL_PATH} ${extra_config_args} ${TOGGLE_WITH_CUDA} ${TOGGLE_WITH_ROCM} \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -50,7 +50,7 @@ FROM rockylinux/rockylinux:8 AS rockylinux8
 FROM rockylinux/rockylinux:9 AS rockylinux9
 FROM rockylinux/rockylinux:10 AS rockylinux10
 
-FROM docker.io/opensuse/leap AS leap
+FROM docker.io/opensuse/leap:15 AS leap
 FROM docker.io/opensuse/tumbleweed AS tumbleweed
 
 FROM ubuntu:jammy AS jammy
@@ -290,7 +290,7 @@ RUN exec &> >(tee /container/logs/base-os.log) \
             ;; \
         *"leap|"*|*"tumbleweed|"*) \
                 add_conf 'export PKG_INSTALL_CMD="zypper --gpg-auto-import-keys --non-interactive install"' \
-                && gcc_v=15 \
+                && gcc_v=14 \
                 && sed -i 's/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/g' /etc/zypp/zypp.conf \
                 && zypper --non-interactive refresh \
                 && zypper --non-interactive update \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -1312,14 +1312,11 @@ RUN exec &> >(tee /container/logs/mpi-iolibs.log) \
     && PIO_INSTALL_PATH="/container/parallelio/${PIO_VERSION}" \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://github.com/NCAR/ParallelIO/archive/refs/tags/${PIO_TAG}.tar.gz | tar zx \
     && cd ./*${PIO_TAG}/ && mkdir -p build && cd build \
-    && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*) \
-            export CFLAGS="-std=gnu17 ${CFLAGS}" \
-            ;; \
-       esac \
     && cmake \
            -Wno-dev \
            -DCMAKE_BUILD_TYPE=MinSizeRel \
+           -DCMAKE_C_STANDARD=11 \
+           -DCMAKE_C_STANDARD_REQUIRED=ON \
            -DCMAKE_INSTALL_PREFIX=${PIO_INSTALL_PATH} \
            -DBUILD_SHARED_LIBS=ON \
            -DPIO_ENABLE_FORTRAN=ON \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -1055,6 +1055,11 @@ RUN exec &> >(tee /container/logs/openmpi.log) \
     && case "${COMPILER_FAMILY}" in \
         "aocc") extra_config_args="--disable-alt-short-float" ;; \
        esac \
+    && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
+        "gcc:1[6-9]."*|"gcc:[2-9][0-9]."*) \
+            export CFLAGS="--param max-inline-insns-single=20000 ${CFLAGS}" \
+            ;; \
+       esac \
     && ./configure --help \
     && (./configure \
            --prefix=${OPENMPI_INSTALL_PATH} ${extra_config_args} ${TOGGLE_WITH_CUDA} ${TOGGLE_WITH_ROCM} \
@@ -1155,14 +1160,11 @@ RUN exec &> >(tee /container/logs/iolibs.log) \
     && BLOSC_INSTALL_PATH="/container/c-blosc/${BLOSC_VERSION}" \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz | tar zx \
     && cd ./c-blosc-${BLOSC_VERSION} \
-    && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*) \
-            export CFLAGS="-std=gnu17 ${CFLAGS}" \
-            ;; \
-       esac \
     && cmake \
            -DCMAKE_INSTALL_PREFIX=${BLOSC_INSTALL_PATH} \
            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+           -DCMAKE_C_STANDARD=11 \
+           -DCMAKE_C_STANDARD_REQUIRED=ON \
            -DCMAKE_INSTALL_DO_STRIP=1 \
            -DPREFER_EXTERNAL_ZLIB=ON \
            -DPREFER_EXTERNAL_ZSTD=ON \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -294,7 +294,7 @@ RUN exec &> >(tee /container/logs/base-os.log) \
                 && sed -i 's/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/g' /etc/zypp/zypp.conf \
                 && zypper --non-interactive refresh \
                 && zypper --non-interactive update \
-                && zypper --non-interactive install \
+                && zypper --non-interactive install --force-resolution --allow-downgrade \
                           procps hostname \
                           gcc${gcc_v}{,-c++,-fortran} gdb \
                           glibc-devel file pkgconf patch \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -999,7 +999,7 @@ RUN exec &> >(tee /container/logs/mpich.log) \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz | tar xz \
     && cd ./mpich-${MPICH_VERSION} \
     && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:15."*) \
+        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*) \
             export CFLAGS="-std=gnu17 -Wno-incompatible-pointer-types ${CFLAGS}" \
             ;; \
        esac \
@@ -1156,7 +1156,7 @@ RUN exec &> >(tee /container/logs/iolibs.log) \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz | tar zx \
     && cd ./c-blosc-${BLOSC_VERSION} \
     && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:15."*|"nvhpc:"*) \
+        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*) \
             export CFLAGS="-std=gnu17 ${CFLAGS}" \
             ;; \
        esac \
@@ -1286,7 +1286,7 @@ RUN exec &> >(tee /container/logs/mpi-iolibs.log) \
     && cd /tmp && curl --retry 3 --retry-delay 5 -sSL https://parallel-netcdf.github.io/Release/pnetcdf-${PNETCDF_VERSION}.tar.gz | tar zx \
     && cd ./pnetcdf-${PNETCDF_VERSION} \
     && case "${COMPILER_FAMILY}:${GCC_VERSION}" in \
-        "gcc:15."*|"nvhpc:"*) \
+        "gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*) \
             export CFLAGS="-std=gnu17 ${CFLAGS}" \
             ;; \
        esac \

--- a/containers/devenv/Dockerfile
+++ b/containers/devenv/Dockerfile
@@ -648,8 +648,8 @@ LABEL oneapi="${ONEAPI_VERSION}"
 FROM toolkits AS aocc
 #-------------------------------------------------------------------------------
 # https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/aocc/package.py
-ARG AOCC_VERSION="5.1.0"
-ARG AOCC_URL="https://download.amd.com/developer/eula/aocc/aocc-5-1/aocc-compiler-5.1.0.tar"
+ARG AOCC_VERSION="5.2.0"
+ARG AOCC_URL="https://download.amd.com/developer/eula/aocc/aocc-5-2/aocc-compiler-5.2.0.tar"
 RUN exec &> >(tee /container/logs/aocc.log) \
     && echo "Installing AMD AOCC-${AOCC_VERSION}" \
     && echo "AMD AOCC: https://www.amd.com/en/developer/aocc/aocc-compiler/eula.html" >> /container/EULAs.txt \

--- a/containers/test/Dockerfile
+++ b/containers/test/Dockerfile
@@ -42,7 +42,7 @@ EOF
 
 RUN echo "Testing Image from ${BASE_IMAGE} ..." \
     && mpicxx -o ./hello_world_mpi /container/extras/hello_world_mpi.cxx -fopenmp \
-    && ldd ./hello_world_mpi \
+    && report_cpu_features ./hello_world_mpi \
     && export OMP_NUM_THREADS=2 \
     && mpiexec -n 2 ./hello_world_mpi \
     && docker-clean


### PR DESCRIPTION
Routine refresh of the `devenv` software stack — bumps compilers, MPI, and IO/scientific
libraries to current releases and **adds gcc-15 / gcc-16 to the matrix**. The new compilers
(C23-by-default) and a rolled openSUSE Leap base surfaced a cluster of toolchain breakages;
the bulk of this PR is the targeted fixes for those, all validated through the dev matrix.

## Version bumps

| Component | New |
|---|---|
| Intel OneAPI (C++/Fortran) | **2026.0.0** |
| NVHPC (x86_64 + aarch64) | **26.5** |
| AOCC | **5.2.0** |
| MPICH | **5.0.1** |
| HDF5 | **1.14.5** |
| NetCDF-C | **4.10.0** |
| NetCDF-Fortran | **4.6.3** |
| ParallelIO (PIO) | **2.6.7** |
| GCC source-builds | **gcc12 12.5.0, gcc14 14.3.0, gcc15 15.3.0, gcc16 16.1.0** |

Unchanged: PnetCDF 1.14.1, FFTW 3.3.10, HeFFTe 2.4.1.

## Matrix / base-OS changes

- **Add `gcc15` (15.3.0) and `gcc16` (16.1.0)** built-from-source compilers — in the base
  `compiler:` axis *and* with `include:` build-args (an `include:`-only value can't fan out).
- **Exclude `gcc16 + openmpi`**: OpenMPI 5.0.10 hits a GCC-16 `always_inline` inlining error;
  the fix lands upstream in 5.0.11, so the combo is skipped rather than carrying a workaround
  (`reevaluate with 5.0.11`). gcc-15 OpenMPI and gcc16 + mpich are clean.
- **Leap base pinned to `opensuse/leap:15` + system gcc-14** — see below.

## Toolchain fixes

**C23 default (`-std=gnu23`) on gcc ≥15 / nvhpc.** Legacy C (`c-blosc`, `pnetcdf`, `MPICH`,
PIO's bundled GPTL) breaks under C23 (`bool`/`_Bool` keyword & `typedef` errors). Handling:

- Per-library `-std=gnu17` guards widened to a forward-looking, family-aware match
  (`"gcc:1[5-9]."*|"gcc:[2-9][0-9]."*|"nvhpc:"*`) for **MPICH5** and **pnetcdf**.
- **PIO** and **c-blosc** pin the standard via the CMake cache
  (`-DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON`) instead of `$CFLAGS`, because the
  env var doesn't reach them reliably: GPTL is a nested `project()`, and c-blosc only threads
  `$CFLAGS` through on its recognized-CPU (x86) branch — so on **aarch64** it built
  `shuffle.c` under C23 and failed there while x86_64 passed. `REQUIRED=ON` forces the
  downgrade from the compiler's newer default and is global, so it covers both arches.

**Leap base.** The rolling `opensuse/leap` tag moved to **Leap 16.0** (system gcc-15, `gcc14`
package dropped), which broke nvhpc/os-gcc (C23) *and* the CUDA runfile installer's own gcc
check. Pin `FROM opensuse/leap:15` + `gcc_v=14` to keep a pre-C23 system gcc — one root-cause
lever for the whole class. Also added `zypper --force-resolution --allow-downgrade` for a new
`libxml2-devel` → `readline-devel` → `libncurses6` conflict on the 15.x repos.

**CUDA.** Skip the incompatible CUDA legs (gcc ≥15 fails the installer's host-gcc check).

**nvhpc SIGILL (`-march` is ignored; use `-tp`).** nvhpc apps died with `Illegal instruction`
at runtime on whichever leg drew a bad build-vs-run runner pairing. Root cause: `nvc` ignores
GNU's `-march=x86-64-v3`, so the portability pin was a silent no-op and nvc targeted the build
runner's native CPU (`-tp znver4` → AVX-512); the smoke test then ran on an AVX2-only runner.
Fixed by giving the nvhpc matrix entry nvc's own ABI target, `MARCH_FLAGS=-tp=x86-64-v3`
(other families keep `-march=…`), so codegen is deterministically AVX2-portable.

**New diagnostic — `report_cpu_features [binary]`** (`/container/bin/`): prints the host SIMD
level and, given an executable, the ISA it *requires* (`readelf` note + `objdump` `%zmm`/SVE
scan). The hello-world smoke tests now call it, so an over-built binary is visible before a
bare SIGILL. Reusable for any executable.

## CI maintenance

- Bump all GitHub Actions with a Node 24 release (`checkout` v4→v5, the `docker/*` actions,
  `upload-artifact`, `setup-miniconda`, `create-pull-request`, `git-auto-commit`) to clear the
  Node 20 deprecation warnings. (`setup-gh`, `delete-old-actions` have no node24 release yet.)

## Docs

- Add/expand project `CLAUDE.md`: build-stage DAG, version-bump workflow, CI layout, and the
  hard-won gotchas — the system-gcc lever, the gcc≥15/C23 `-std=gnu17` pattern, the CMake
  C-standard pin (nested projects & c-blosc's per-arch quirk), the CUDA installer gcc check,
  the nvhpc `-march`-vs-`-tp` trap, and `report_cpu_features`.
